### PR TITLE
Initialize API definitions

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,15 @@
+name: cla-check
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  cla-check:
+    permissions:
+      pull-requests: write  # for canonical/has-signed-canonical-cla to create & update comments
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v1

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*               @canonical/kubernetes

--- a/api/v1/const.go
+++ b/api/v1/const.go
@@ -1,0 +1,11 @@
+package apiv1
+
+const (
+	// K8sdAPIVersion is the path prefix that will be used for the k8sd endpoints for this api version.
+	K8sdAPIVersion = "1.0"
+
+	// AnnotationSkipCleanupKubernetesNodeOnRemove if set, only the microcluster & file cleanup is done.
+	// This is useful, if an external controller (e.g. CAPI) is responsible for the Kubernetes node life cycle.
+	// By default, the Kubernetes node is removed by k8sd if a node is removed from the cluster.
+	AnnotationSkipCleanupKubernetesNodeOnRemove = "k8sd/v1alpha/lifecycle/skip-cleanup-kubernetes-node-on-remove"
+)

--- a/api/v1/rpc_bootstrap_cluster.go
+++ b/api/v1/rpc_bootstrap_cluster.go
@@ -1,0 +1,17 @@
+package apiv1
+
+import "time"
+
+// BootstrapClusterRPC is the path for the BootstrapCluster RPC.
+const BootstrapClusterRPC = "k8sd/cluster"
+
+// BootstrapClusterRequest is the request message for the BootstrapCluster RPC.
+type BootstrapClusterRequest struct {
+	Name    string          `json:"name"`
+	Address string          `json:"address"`
+	Config  BootstrapConfig `json:"config"`
+	Timeout time.Duration   `json:"timeout"`
+}
+
+// BootstrapClusterResponse is the response message for the BootstrapClusterRPC.
+type BootstrapClusterResponse struct{}

--- a/api/v1/rpc_bootstrap_cluster.go
+++ b/api/v1/rpc_bootstrap_cluster.go
@@ -14,4 +14,4 @@ type BootstrapClusterRequest struct {
 }
 
 // BootstrapClusterResponse is the response message for the BootstrapClusterRPC.
-type BootstrapClusterResponse struct{}
+type BootstrapClusterResponse NodeStatus

--- a/api/v1/rpc_cluster_status.go
+++ b/api/v1/rpc_cluster_status.go
@@ -1,0 +1,12 @@
+package apiv1
+
+// ClusterStatusRPC is the path for the ClusterStatus RPC.
+const ClusterStatusRPC = "k8sd/cluster"
+
+// ClusterStatusRequest is the request message for the ClusterStatus RPC.
+type ClusterStatusRequest struct{}
+
+// ClusterStatusResponse is the response message for the ClusterStatus RPC.
+type ClusterStatusResponse struct {
+	ClusterStatus ClusterStatus `json:"status"`
+}

--- a/api/v1/rpc_clusterapi_get_join_token.go
+++ b/api/v1/rpc_clusterapi_get_join_token.go
@@ -1,0 +1,10 @@
+package apiv1
+
+// ClusterAPIGetJoinTokenRPC is the path for the ClusterAPIGetJoinToken RPC.
+const ClusterAPIGetJoinTokenRPC = "x/capi/generate-join-token"
+
+// ClusterAPIGetJoinTokenRequest is the request message for the ClusterAPIGetJoinToken RPC (same as GetJoinToken).
+type ClusterAPIGetJoinTokenRequest GetJoinTokenRequest
+
+// ClusterAPIGetJoinTokenResponse is the response message for the ClusterAPIGetJoinToken RPC (same as GetJoinToken).
+type ClusterAPIGetJoinTokenResponse GetJoinTokenResponse

--- a/api/v1/rpc_clusterapi_remove_node.go
+++ b/api/v1/rpc_clusterapi_remove_node.go
@@ -1,0 +1,10 @@
+package apiv1
+
+// ClusterAPIRemoveNodeRPC is the path for the ClusterAPIRemoveNode RPC.
+const ClusterAPIRemoveNodeRPC = "x/capi/remove-node"
+
+// ClusterAPIRemoveNodeRequest is the request message for the ClusterAPIRemoveNode RPC (same as RemoveNode).
+type ClusterAPIRemoveNodeRequest RemoveNodeRequest
+
+// ClusterAPIRemoveNodeResponse is the response message for the ClusterAPIRemoveNode RPC (same as RemoveNode).
+type ClusterAPIRemoveNodeResponse RemoveNodeResponse

--- a/api/v1/rpc_clusterapi_set_auth_token.go
+++ b/api/v1/rpc_clusterapi_set_auth_token.go
@@ -1,7 +1,7 @@
 package apiv1
 
 // ClusterAPISetAuthTokenRPC is the path for the ClusterAPISetAuthToken RPC.
-const ClusterAPISetAuthTokenRPC = "k8sd/cluster"
+const ClusterAPISetAuthTokenRPC = "x/capi/set-auth-token"
 
 // ClusterAPISetAuthTokenRequest is the request message for the ClusterAPISetAuthToken RPC.
 type ClusterAPISetAuthTokenRequest struct {

--- a/api/v1/rpc_clusterapi_set_auth_token.go
+++ b/api/v1/rpc_clusterapi_set_auth_token.go
@@ -1,0 +1,12 @@
+package apiv1
+
+// ClusterAPISetAuthTokenRPC is the path for the ClusterAPISetAuthToken RPC.
+const ClusterAPISetAuthTokenRPC = "k8sd/cluster"
+
+// ClusterAPISetAuthTokenRequest is the request message for the ClusterAPISetAuthToken RPC.
+type ClusterAPISetAuthTokenRequest struct {
+	Token string `json:"token"`
+}
+
+// ClusterAPISetAuthTokenResponse is the response message for the ClusterAPISetAuthToken RPC.
+type ClusterAPISetAuthTokenResponse struct{}

--- a/api/v1/rpc_generate_kubernetes_auth_token.go
+++ b/api/v1/rpc_generate_kubernetes_auth_token.go
@@ -1,0 +1,15 @@
+package apiv1
+
+// GenerateKubernetesAuthTokenRPC is the path for the GenerateKubernetesAuthToken RPC.
+const GenerateKubernetesAuthTokenRPC = "kubernetes/auth/tokens"
+
+// GenerateKubernetesAuthTokenRequest is the request message for the GenerateKubernetesAuthToken RPC.
+type GenerateKubernetesAuthTokenRequest struct {
+	Username string   `json:"username"`
+	Groups   []string `json:"groups"`
+}
+
+// GenerateKubernetesAuthTokenResponse is the response message for the GenerateKubernetesAuthToken RPC.
+type GenerateKubernetesAuthTokenResponse struct {
+	Token string `json:"token"`
+}

--- a/api/v1/rpc_get_cluster_config.go
+++ b/api/v1/rpc_get_cluster_config.go
@@ -1,0 +1,12 @@
+package apiv1
+
+// GetClusterConfigRPC is the path for the GetClusterConfig RPC.
+const GetClusterConfigRPC = "k8sd/cluster/config"
+
+// GetClusterConfigRequest is the request message for the GetClusterConfig RPC.
+type GetClusterConfigRequest struct{}
+
+// GetClusterConfigResponse is the response message for the GetClusterConfig RPC.
+type GetClusterConfigResponse struct {
+	Config UserFacingClusterConfig `json:"status"`
+}

--- a/api/v1/rpc_get_join_token.go
+++ b/api/v1/rpc_get_join_token.go
@@ -1,0 +1,18 @@
+package apiv1
+
+// GetJoinTokenRPC is the path for the GetJoinToken RPC.
+const GetJoinTokenRPC = "k8sd/cluster/tokens"
+
+// GetJoinTokenRequest is the request message for the GetJoinToken RPC.
+type GetJoinTokenRequest struct {
+	// Name is the name of the token to generate.
+	Name string `json:"name"`
+	// Worker should be set to true to generate a token for joining a worker node.
+	Worker bool `json:"worker"`
+}
+
+// GetJoinTokenResponse is the response message for the GetJoinToken RPC.
+type GetJoinTokenResponse struct {
+	// EncodedToken is the generated join token.
+	EncodedToken string `json:"token"`
+}

--- a/api/v1/rpc_get_worker_join_info.go
+++ b/api/v1/rpc_get_worker_join_info.go
@@ -1,0 +1,44 @@
+package apiv1
+
+// GetWorkerJoinInfoRPC is the path for the GetWorkerJoinInfo RPC.
+const GetWorkerJoinInfoRPC = "k8sd/worker/info"
+
+// GetWorkerJoinInfoRequest is the request message for the GetWorkerJoinInfo RPC.
+type GetWorkerJoinInfoRequest struct {
+	// Address is the address of the worker node.
+	Address string `json:"address"`
+}
+
+// GetWorkerJoinInfoResponse is the response message for the GetWorkerJoinInfo RPC.
+type GetWorkerJoinInfoResponse struct {
+	// CACert is the PEM encoded certificate authority of the cluster.
+	CACert string `json:"ca,omitempty"`
+	// ClientCACert is the PEM encoded certificate authority of the cluster clients.
+	ClientCACert string `json:"client-ca,omitempty"`
+	// APIServers is a list of kube-apiserver endpoints of the cluster.
+	APIServers []string `json:"apiServers"`
+	// KubeletClientCert is the certificate to use in kubelet to authenticate with kube-apiserver.
+	KubeletClientCert string `json:"kubeletClientCert"`
+	// KubeletClientKey is the private key to use in kubelet to authenticate with kube-apiserver.
+	KubeletClientKey string `json:"kubeletClientKey"`
+	// KubeProxyClientCert is the certificate to use in kube-proxy to authenticate with kube-apiserver.
+	KubeProxyClientCert string `json:"kubeProxyClientCert"`
+	// KubeProxyClientKey is the private key to use in kube-proxy to authenticate with kube-apiserver.
+	KubeProxyClientKey string `json:"kubeProxyClientKey"`
+	// PodCIDR is the configured CIDR for pods in the cluster.
+	PodCIDR string `json:"podCIDR"`
+	// ServiceCIDR is the configured CIDR for services in the cluster.
+	ServiceCIDR string `json:"serviceCIDR"`
+	// ClusterDNS is the DNS server address of the cluster.
+	ClusterDNS string `json:"clusterDNS,omitempty"`
+	// ClusterDomain is the DNS domain of the cluster.
+	ClusterDomain string `json:"clusterDomain,omitempty"`
+	// CloudProvider is the cloud provider used in the cluster.
+	CloudProvider string `json:"cloudProvider,omitempty"`
+	// KubeletCert is the certificate to use for kubelet TLS. It will be empty if the cluster is not using self-signed certificates.
+	KubeletCert string `json:"kubeletCrt,omitempty"`
+	// KubeletKey is the private key to use for kubelet TLS. It will be empty if the cluster is not using self-signed certificates.
+	KubeletKey string `json:"kubeletKey,omitempty"`
+	// K8sdPublicKey is the public key that can be used to validate authenticity of cluster messages.
+	K8sdPublicKey string `json:"k8sdPublicKey,omitempty"`
+}

--- a/api/v1/rpc_join_cluster.go
+++ b/api/v1/rpc_join_cluster.go
@@ -1,0 +1,23 @@
+package apiv1
+
+import "time"
+
+// JoinClusterRPC is the path for the JoinCluster RPC.
+const JoinClusterRPC = "k8sd/cluster/join"
+
+// JoinClusterRequest is the request message for the JoinCluster RPC.
+type JoinClusterRequest struct {
+	// Name of the node that joins.
+	Name string `json:"name"`
+	// Address to use for microcluster on the joining node.
+	Address string `json:"address"`
+	// Token is the join token.
+	Token string `json:"token"`
+	// Config is JSON formatted string of a ControlPlaneJoinConfig (for control plane) or a WorkerJoinConfig (for worker nodes).
+	Config string `json:"config"`
+	// Timeout is how long to wait until the join is complete.
+	Timeout time.Duration `json:"timeout"`
+}
+
+// JoinClusterResponse is the response message for the JoinCluster RPC.
+type JoinClusterResponse struct{}

--- a/api/v1/rpc_kubeconfig.go
+++ b/api/v1/rpc_kubeconfig.go
@@ -1,0 +1,16 @@
+package apiv1
+
+// KubeConfigRPC is the path for the KubeConfig RPC.
+const KubeConfigRPC = "k8sd/kubeconfig"
+
+// KubeConfigRequest is the request message for the KubeConfig RPC.
+type KubeConfigRequest struct {
+	// Server is the server URL to use (e.g. in case of an external LoadBalancer endpoint).
+	Server string `json:"server"`
+}
+
+// KubeConfigResponse is the response message for the KubeConfig RPC.
+type KubeConfigResponse struct {
+	// KubeConfig is an admin kubeconfig that can be used to access the cluster.
+	KubeConfig string `json:"kubeconfig"`
+}

--- a/api/v1/rpc_node_status.go
+++ b/api/v1/rpc_node_status.go
@@ -1,0 +1,12 @@
+package apiv1
+
+// NodeStatusRPC is the path for the NodeStatus RPC.
+const NodeStatusRPC = "k8sd/cluster"
+
+// NodeStatusRequest is the request message for the NodeStatus RPC.
+type NodeStatusRequest struct{}
+
+// NodeStatusResponse is the response message for the NodeStatus RPC.
+type NodeStatusResponse struct {
+	NodeStatus NodeStatus `json:"status"`
+}

--- a/api/v1/rpc_node_status.go
+++ b/api/v1/rpc_node_status.go
@@ -1,7 +1,7 @@
 package apiv1
 
 // NodeStatusRPC is the path for the NodeStatus RPC.
-const NodeStatusRPC = "k8sd/cluster"
+const NodeStatusRPC = "k8sd/node"
 
 // NodeStatusRequest is the request message for the NodeStatus RPC.
 type NodeStatusRequest struct{}

--- a/api/v1/rpc_refresh_certificates_plan.go
+++ b/api/v1/rpc_refresh_certificates_plan.go
@@ -1,0 +1,15 @@
+package apiv1
+
+// RefreshCertificatesPlanRPC is the path for the RefreshCertificatesPlan RPC.
+const RefreshCertificatesPlanRPC = "k8sd/refresh-certs/plan"
+
+// RefreshCertificatesPlanRequest is the request message for the RefreshCertificatesPlan RPC.
+type RefreshCertificatesPlanRequest struct{}
+
+// RefreshCertificatesPlanResponse is the response message for the RefreshCertificatesPlan RPC.
+type RefreshCertificatesPlanResponse struct {
+	// Seed should be passed by clients to the RefreshCertificatesRun RPC.
+	Seed int `json:"seconds"`
+	// CertificateSigningRequests is a list of names of the CertificateSigningRequests that need to be signed externally (for worker nodes).
+	CertificateSigningRequests []string `json:"certificate-signing-requests"`
+}

--- a/api/v1/rpc_refresh_certificates_run.go
+++ b/api/v1/rpc_refresh_certificates_run.go
@@ -1,0 +1,18 @@
+package apiv1
+
+// RefreshCertificatesRunRPC is the path for the RefreshCertificatesRun RPC.
+const RefreshCertificatesRunRPC = "k8sd/refresh-certs/run"
+
+// RefreshCertificatesRunRequest is the request message for the RefreshCertificatesRun RPC.
+type RefreshCertificatesRunRequest struct {
+	// Seed must match the value returned by the RefreshCertificatesPlan RPC.
+	Seed int `json:"seed"`
+	// ExpirationSeconds is the desired duration of the new certificates.
+	ExpirationSeconds int `json:"expiration-seconds"`
+}
+
+// RefreshCertificatesRunResponse is the response message for the RefreshCertificatesRun RPC.
+type RefreshCertificatesRunResponse struct {
+	// ExpirationSeconds is the duration of the new certificates (might not match the requested value).
+	ExpirationSeconds int `json:"expiration-seconds"`
+}

--- a/api/v1/rpc_refresh_certificates_run.go
+++ b/api/v1/rpc_refresh_certificates_run.go
@@ -10,6 +10,7 @@ type RefreshCertificatesRunRequest struct {
 	// ExpirationSeconds is the desired duration of the new certificates.
 	ExpirationSeconds int `json:"expiration-seconds"`
 	// ExtraSANs is a list of extra SANs (DNS names or IP addresses) to add to the kube-apiserver certificates.
+	// ExtraSANs is ignored for worker nodes.
 	ExtraSANs []string `json:"extra-sans"`
 }
 

--- a/api/v1/rpc_refresh_certificates_run.go
+++ b/api/v1/rpc_refresh_certificates_run.go
@@ -9,6 +9,8 @@ type RefreshCertificatesRunRequest struct {
 	Seed int `json:"seed"`
 	// ExpirationSeconds is the desired duration of the new certificates.
 	ExpirationSeconds int `json:"expiration-seconds"`
+	// ExtraSANs is a list of extra SANs (DNS names or IP addresses) to add to the kube-apiserver certificates.
+	ExtraSANs []string `json:"extra-sans"`
 }
 
 // RefreshCertificatesRunResponse is the response message for the RefreshCertificatesRun RPC.

--- a/api/v1/rpc_remove_node.go
+++ b/api/v1/rpc_remove_node.go
@@ -1,0 +1,16 @@
+package apiv1
+
+import "time"
+
+// RemoveNodeRPC is the path for the RemoveNode RPC.
+const RemoveNodeRPC = "k8sd/cluster/remove"
+
+// RemoveNodeRequest is the request message for the RemoveNode RPC.
+type RemoveNodeRequest struct {
+	Name    string        `json:"name"`
+	Force   bool          `json:"force"`
+	Timeout time.Duration `json:"timeout"`
+}
+
+// RemoveNodeResponse is the response message for the RemoveNode RPC.
+type RemoveNodeResponse struct{}

--- a/api/v1/rpc_revoke_kubernetes_auth_token.go
+++ b/api/v1/rpc_revoke_kubernetes_auth_token.go
@@ -1,0 +1,12 @@
+package apiv1
+
+// RevokeKubernetesAuthTokenRPC is the path for the RevokeKubernetesAuthToken RPC.
+const RevokeKubernetesAuthTokenRPC = "kubernetes/auth/tokens"
+
+// RevokeKubernetesAuthTokenRequest is the request message for the RevokeKubernetesAuthToken RPC.
+type RevokeKubernetesAuthTokenRequest struct {
+	Token string `json:"token"`
+}
+
+// RevokeKubernetesAuthTokenResponse is the response message for the RevokeKubernetesAuthToken RPC.
+type RevokeKubernetesAuthTokenResponse struct{}

--- a/api/v1/rpc_set_cluster_config.go
+++ b/api/v1/rpc_set_cluster_config.go
@@ -1,0 +1,13 @@
+package apiv1
+
+// SetClusterConfigRPC is the path for the SetClusterConfig RPC.
+const SetClusterConfigRPC = "k8sd/cluster/config"
+
+// SetClusterConfigRequest is the request message for the SetClusterConfig RPC.
+type SetClusterConfigRequest struct {
+	Config    UserFacingClusterConfig   `json:"config,omitempty" yaml:"config,omitempty"`
+	Datastore UserFacingDatastoreConfig `json:"datastore,omitempty" yaml:"datastore,omitempty"`
+}
+
+// SetClusterConfigResponse is the response message for the SetClusterConfig RPC.
+type SetClusterConfigResponse struct{}

--- a/api/v1/type_bootstrap_config.go
+++ b/api/v1/type_bootstrap_config.go
@@ -1,11 +1,6 @@
 package apiv1
 
-import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/canonical/k8s-snap-api-v1/internal/util"
-)
+import "github.com/canonical/k8s-snap-api-v1/internal/util"
 
 // BootstrapConfig is used to seed cluster configuration when bootstrapping a new cluster.
 type BootstrapConfig struct {
@@ -112,24 +107,3 @@ func (b *BootstrapConfig) GetKubeletCert() string       { return util.Deref(b.Ku
 func (b *BootstrapConfig) GetKubeletKey() string        { return util.Deref(b.KubeletKey) }
 func (b *BootstrapConfig) GetKubeletClientCert() string { return util.Deref(b.KubeletClientCert) }
 func (b *BootstrapConfig) GetKubeletClientKey() string  { return util.Deref(b.KubeletClientKey) }
-
-// ToMicrocluster converts a BootstrapConfig to a map[string]string for use in microcluster.
-func (b *BootstrapConfig) ToMicrocluster() (map[string]string, error) {
-	config, err := json.Marshal(b)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal bootstrap config: %w", err)
-	}
-
-	return map[string]string{
-		"bootstrapConfig": string(config),
-	}, nil
-}
-
-// BootstrapConfigFromMicrocluster parses a microcluster map[string]string and retrieves the BootstrapConfig.
-func BootstrapConfigFromMicrocluster(m map[string]string) (BootstrapConfig, error) {
-	config := BootstrapConfig{}
-	if err := json.Unmarshal([]byte(m["bootstrapConfig"]), &config); err != nil {
-		return BootstrapConfig{}, fmt.Errorf("failed to unmarshal bootstrap config: %w", err)
-	}
-	return config, nil
-}

--- a/api/v1/type_bootstrap_config.go
+++ b/api/v1/type_bootstrap_config.go
@@ -1,0 +1,135 @@
+package apiv1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/canonical/k8s-snap-api/internal/util"
+)
+
+// BootstrapConfig is used to seed cluster configuration when bootstrapping a new cluster.
+type BootstrapConfig struct {
+	// ClusterConfig
+	ClusterConfig UserFacingClusterConfig `json:"cluster-config,omitempty" yaml:"cluster-config,omitempty"`
+
+	// Seed configuration for the control plane (flat on purpose). Empty values are ignored
+	ControlPlaneTaints  []string `json:"control-plane-taints,omitempty" yaml:"control-plane-taints,omitempty"`
+	PodCIDR             *string  `json:"pod-cidr,omitempty" yaml:"pod-cidr,omitempty"`
+	ServiceCIDR         *string  `json:"service-cidr,omitempty" yaml:"service-cidr,omitempty"`
+	DisableRBAC         *bool    `json:"disable-rbac,omitempty" yaml:"disable-rbac,omitempty"`
+	SecurePort          *int     `json:"secure-port,omitempty" yaml:"secure-port,omitempty"`
+	K8sDqlitePort       *int     `json:"k8s-dqlite-port,omitempty" yaml:"k8s-dqlite-port,omitempty"`
+	DatastoreType       *string  `json:"datastore-type,omitempty" yaml:"datastore-type,omitempty"`
+	DatastoreServers    []string `json:"datastore-servers,omitempty" yaml:"datastore-servers,omitempty"`
+	DatastoreCACert     *string  `json:"datastore-ca-crt,omitempty" yaml:"datastore-ca-crt,omitempty"`
+	DatastoreClientCert *string  `json:"datastore-client-crt,omitempty" yaml:"datastore-client-crt,omitempty"`
+	DatastoreClientKey  *string  `json:"datastore-client-key,omitempty" yaml:"datastore-client-key,omitempty"`
+
+	// Seed configuration for certificates
+	ExtraSANs []string `json:"extra-sans,omitempty" yaml:"extra-sans,omitempty"`
+
+	// Seed configuration for external certificates (cluster-wide)
+	CACert                          *string `json:"ca-crt,omitempty" yaml:"ca-crt,omitempty"`
+	CAKey                           *string `json:"ca-key,omitempty" yaml:"ca-key,omitempty"`
+	ClientCACert                    *string `json:"client-ca-crt,omitempty" yaml:"client-ca-crt,omitempty"`
+	ClientCAKey                     *string `json:"client-ca-key,omitempty" yaml:"client-ca-key,omitempty"`
+	FrontProxyCACert                *string `json:"front-proxy-ca-crt,omitempty" yaml:"front-proxy-ca-crt,omitempty"`
+	FrontProxyCAKey                 *string `json:"front-proxy-ca-key,omitempty" yaml:"front-proxy-ca-key,omitempty"`
+	FrontProxyClientCert            *string `json:"front-proxy-client-crt,omitempty" yaml:"front-proxy-client-crt,omitempty"`
+	FrontProxyClientKey             *string `json:"front-proxy-client-key,omitempty" yaml:"front-proxy-client-key,omitempty"`
+	APIServerKubeletClientCert      *string `json:"apiserver-kubelet-client-crt,omitempty" yaml:"apiserver-kubelet-client-crt,omitempty"`
+	APIServerKubeletClientKey       *string `json:"apiserver-kubelet-client-key,omitempty" yaml:"apiserver-kubelet-client-key,omitempty"`
+	AdminClientCert                 *string `json:"admin-client-crt,omitempty" yaml:"admin-client-crt,omitempty"`
+	AdminClientKey                  *string `json:"admin-client-key,omitempty" yaml:"admin-client-key,omitempty"`
+	KubeProxyClientCert             *string `json:"kube-proxy-client-crt,omitempty" yaml:"kube-proxy-client-crt,omitempty"`
+	KubeProxyClientKey              *string `json:"kube-proxy-client-key,omitempty" yaml:"kube-proxy-client-key,omitempty"`
+	KubeSchedulerClientCert         *string `json:"kube-scheduler-client-crt,omitempty" yaml:"kube-scheduler-client-crt,omitempty"`
+	KubeSchedulerClientKey          *string `json:"kube-scheduler-client-key,omitempty" yaml:"kube-scheduler-client-key,omitempty"`
+	KubeControllerManagerClientCert *string `json:"kube-controller-manager-client-crt,omitempty" yaml:"kube-controller-manager-client-crt,omitempty"`
+	KubeControllerManagerClientKey  *string `json:"kube-controller-manager-client-key,omitempty" yaml:"kube-ControllerManager-client-key,omitempty"`
+	ServiceAccountKey               *string `json:"service-account-key,omitempty" yaml:"service-account-key,omitempty"`
+
+	// Seed configuration for external certificates (node-specific)
+	APIServerCert     *string `json:"apiserver-crt,omitempty" yaml:"apiserver-crt,omitempty"`
+	APIServerKey      *string `json:"apiserver-key,omitempty" yaml:"apiserver-key,omitempty"`
+	KubeletCert       *string `json:"kubelet-crt,omitempty" yaml:"kubelet-crt,omitempty"`
+	KubeletKey        *string `json:"kubelet-key,omitempty" yaml:"kubelet-key,omitempty"`
+	KubeletClientCert *string `json:"kubelet-client-crt,omitempty" yaml:"kubelet-client-crt,omitempty"`
+	KubeletClientKey  *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
+
+	// ExtraNodeConfigFiles will be written to /var/snap/k8s/common/args/conf.d
+	ExtraNodeConfigFiles map[string]string `json:"extra-node-config-files,omitempty" yaml:"extra-node-config-files,omitempty"`
+
+	// Extra args to add to individual services (set any arg to null to delete)
+	ExtraNodeKubeAPIServerArgs         map[string]*string `json:"extra-node-kube-apiserver-args,omitempty" yaml:"extra-node-kube-apiserver-args,omitempty"`
+	ExtraNodeKubeControllerManagerArgs map[string]*string `json:"extra-node-kube-controller-manager-args,omitempty" yaml:"extra-node-kube-controller-manager-args,omitempty"`
+	ExtraNodeKubeSchedulerArgs         map[string]*string `json:"extra-node-kube-scheduler-args,omitempty" yaml:"extra-node-kube-scheduler-args,omitempty"`
+	ExtraNodeKubeProxyArgs             map[string]*string `json:"extra-node-kube-proxy-args,omitempty" yaml:"extra-node-kube-proxy-args,omitempty"`
+	ExtraNodeKubeletArgs               map[string]*string `json:"extra-node-kubelet-args,omitempty" yaml:"extra-node-kubelet-args,omitempty"`
+	ExtraNodeContainerdArgs            map[string]*string `json:"extra-node-containerd-args,omitempty" yaml:"extra-node-containerd-args,omitempty"`
+	ExtraNodeK8sDqliteArgs             map[string]*string `json:"extra-node-k8s-dqlite-args,omitempty" yaml:"extra-node-k8s-dqlite-args,omitempty"`
+}
+
+func (b *BootstrapConfig) GetDatastoreType() string        { return util.Deref(b.DatastoreType) }
+func (b *BootstrapConfig) GetDatastoreCACert() string      { return util.Deref(b.DatastoreCACert) }
+func (b *BootstrapConfig) GetDatastoreClientCert() string  { return util.Deref(b.DatastoreClientCert) }
+func (b *BootstrapConfig) GetDatastoreClientKey() string   { return util.Deref(b.DatastoreClientKey) }
+func (b *BootstrapConfig) GetK8sDqlitePort() int           { return util.Deref(b.K8sDqlitePort) }
+func (b *BootstrapConfig) GetCACert() string               { return util.Deref(b.CACert) }
+func (b *BootstrapConfig) GetCAKey() string                { return util.Deref(b.CAKey) }
+func (b *BootstrapConfig) GetClientCACert() string         { return util.Deref(b.ClientCACert) }
+func (b *BootstrapConfig) GetClientCAKey() string          { return util.Deref(b.ClientCAKey) }
+func (b *BootstrapConfig) GetFrontProxyCACert() string     { return util.Deref(b.FrontProxyCACert) }
+func (b *BootstrapConfig) GetFrontProxyCAKey() string      { return util.Deref(b.FrontProxyCAKey) }
+func (b *BootstrapConfig) GetFrontProxyClientCert() string { return util.Deref(b.FrontProxyClientCert) }
+func (b *BootstrapConfig) GetFrontProxyClientKey() string  { return util.Deref(b.FrontProxyClientKey) }
+func (b *BootstrapConfig) GetAPIServerKubeletClientCert() string {
+	return util.Deref(b.APIServerKubeletClientCert)
+}
+func (b *BootstrapConfig) GetAPIServerKubeletClientKey() string {
+	return util.Deref(b.APIServerKubeletClientKey)
+}
+func (b *BootstrapConfig) GetAdminClientCert() string     { return util.Deref(b.AdminClientCert) }
+func (b *BootstrapConfig) GetAdminClientKey() string      { return util.Deref(b.AdminClientKey) }
+func (b *BootstrapConfig) GetKubeProxyClientCert() string { return util.Deref(b.KubeProxyClientCert) }
+func (b *BootstrapConfig) GetKubeProxyClientKey() string  { return util.Deref(b.KubeProxyClientKey) }
+func (b *BootstrapConfig) GetKubeSchedulerClientCert() string {
+	return util.Deref(b.KubeSchedulerClientCert)
+}
+func (b *BootstrapConfig) GetKubeSchedulerClientKey() string {
+	return util.Deref(b.KubeSchedulerClientKey)
+}
+func (b *BootstrapConfig) GetKubeControllerManagerClientCert() string {
+	return util.Deref(b.KubeControllerManagerClientCert)
+}
+func (b *BootstrapConfig) GetKubeControllerManagerClientKey() string {
+	return util.Deref(b.KubeControllerManagerClientKey)
+}
+func (b *BootstrapConfig) GetServiceAccountKey() string { return util.Deref(b.ServiceAccountKey) }
+func (b *BootstrapConfig) GetAPIServerCert() string     { return util.Deref(b.APIServerCert) }
+func (b *BootstrapConfig) GetAPIServerKey() string      { return util.Deref(b.APIServerKey) }
+func (b *BootstrapConfig) GetKubeletCert() string       { return util.Deref(b.KubeletCert) }
+func (b *BootstrapConfig) GetKubeletKey() string        { return util.Deref(b.KubeletKey) }
+func (b *BootstrapConfig) GetKubeletClientCert() string { return util.Deref(b.KubeletClientCert) }
+func (b *BootstrapConfig) GetKubeletClientKey() string  { return util.Deref(b.KubeletClientKey) }
+
+// ToMicrocluster converts a BootstrapConfig to a map[string]string for use in microcluster.
+func (b *BootstrapConfig) ToMicrocluster() (map[string]string, error) {
+	config, err := json.Marshal(b)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal bootstrap config: %w", err)
+	}
+
+	return map[string]string{
+		"bootstrapConfig": string(config),
+	}, nil
+}
+
+// BootstrapConfigFromMicrocluster parses a microcluster map[string]string and retrieves the BootstrapConfig.
+func BootstrapConfigFromMicrocluster(m map[string]string) (BootstrapConfig, error) {
+	config := BootstrapConfig{}
+	if err := json.Unmarshal([]byte(m["bootstrapConfig"]), &config); err != nil {
+		return BootstrapConfig{}, fmt.Errorf("failed to unmarshal bootstrap config: %w", err)
+	}
+	return config, nil
+}

--- a/api/v1/type_bootstrap_config.go
+++ b/api/v1/type_bootstrap_config.go
@@ -1,6 +1,6 @@
 package apiv1
 
-import "github.com/canonical/k8s-snap-api-v1/internal/util"
+import "github.com/canonical/k8s-snap-api/internal/util"
 
 // BootstrapConfig is used to seed cluster configuration when bootstrapping a new cluster.
 type BootstrapConfig struct {

--- a/api/v1/type_bootstrap_config.go
+++ b/api/v1/type_bootstrap_config.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/canonical/k8s-snap-api/internal/util"
+	"github.com/canonical/k8s-snap-api-v1/internal/util"
 )
 
 // BootstrapConfig is used to seed cluster configuration when bootstrapping a new cluster.

--- a/api/v1/type_cluster_config.go
+++ b/api/v1/type_cluster_config.go
@@ -3,7 +3,7 @@ package apiv1
 import (
 	"fmt"
 
-	"github.com/canonical/k8s-snap-api-v1/internal/util"
+	"github.com/canonical/k8s-snap-api/internal/util"
 	"gopkg.in/yaml.v2"
 )
 

--- a/api/v1/type_cluster_config.go
+++ b/api/v1/type_cluster_config.go
@@ -3,7 +3,7 @@ package apiv1
 import (
 	"fmt"
 
-	"github.com/canonical/k8s-snap-api/internal/util"
+	"github.com/canonical/k8s-snap-api-v1/internal/util"
 	"gopkg.in/yaml.v2"
 )
 

--- a/api/v1/type_cluster_config.go
+++ b/api/v1/type_cluster_config.go
@@ -1,0 +1,173 @@
+package apiv1
+
+import (
+	"fmt"
+
+	"github.com/canonical/k8s-snap-api/internal/util"
+	"gopkg.in/yaml.v2"
+)
+
+type UserFacingClusterConfig struct {
+	Network       NetworkConfig       `json:"network,omitempty" yaml:"network,omitempty"`
+	DNS           DNSConfig           `json:"dns,omitempty" yaml:"dns,omitempty"`
+	Ingress       IngressConfig       `json:"ingress,omitempty" yaml:"ingress,omitempty"`
+	LoadBalancer  LoadBalancerConfig  `json:"load-balancer,omitempty" yaml:"load-balancer,omitempty"`
+	LocalStorage  LocalStorageConfig  `json:"local-storage,omitempty" yaml:"local-storage,omitempty"`
+	Gateway       GatewayConfig       `json:"gateway,omitempty" yaml:"gateway,omitempty"`
+	MetricsServer MetricsServerConfig `json:"metrics-server,omitempty" yaml:"metrics-server,omitempty"`
+	CloudProvider *string             `json:"cloud-provider,omitempty" yaml:"cloud-provider,omitempty"`
+	Annotations   map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+}
+
+type DNSConfig struct {
+	Enabled             *bool     `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	ClusterDomain       *string   `json:"cluster-domain,omitempty" yaml:"cluster-domain,omitempty"`
+	ServiceIP           *string   `json:"service-ip,omitempty" yaml:"service-ip,omitempty"`
+	UpstreamNameservers *[]string `json:"upstream-nameservers,omitempty" yaml:"upstream-nameservers,omitempty"`
+}
+
+func (c DNSConfig) GetEnabled() bool                 { return util.Deref(c.Enabled) }
+func (c DNSConfig) GetClusterDomain() string         { return util.Deref(c.ClusterDomain) }
+func (c DNSConfig) GetServiceIP() string             { return util.Deref(c.ServiceIP) }
+func (c DNSConfig) GetUpstreamNameservers() []string { return util.Deref(c.UpstreamNameservers) }
+
+type IngressConfig struct {
+	Enabled             *bool   `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	DefaultTLSSecret    *string `json:"default-tls-secret,omitempty" yaml:"default-tls-secret,omitempty"`
+	EnableProxyProtocol *bool   `json:"enable-proxy-protocol,omitempty" yaml:"enable-proxy-protocol,omitempty"`
+}
+
+func (c IngressConfig) GetEnabled() bool             { return util.Deref(c.Enabled) }
+func (c IngressConfig) GetDefaultTLSSecret() string  { return util.Deref(c.DefaultTLSSecret) }
+func (c IngressConfig) GetEnableProxyProtocol() bool { return util.Deref(c.EnableProxyProtocol) }
+
+type LoadBalancerConfig struct {
+	Enabled        *bool     `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	CIDRs          *[]string `json:"cidrs,omitempty" yaml:"cidrs,omitempty"`
+	L2Mode         *bool     `json:"l2-mode,omitempty" yaml:"l2-mode,omitempty"`
+	L2Interfaces   *[]string `json:"l2-interfaces,omitempty" yaml:"l2-interfaces,omitempty"`
+	BGPMode        *bool     `json:"bgp-mode,omitempty" yaml:"bgp-mode,omitempty"`
+	BGPLocalASN    *int      `json:"bgp-local-asn,omitempty" yaml:"bgp-local-asn,omitempty"`
+	BGPPeerAddress *string   `json:"bgp-peer-address,omitempty" yaml:"bgp-peer-address,omitempty"`
+	BGPPeerASN     *int      `json:"bgp-peer-asn,omitempty" yaml:"bgp-peer-asn,omitempty"`
+	BGPPeerPort    *int      `json:"bgp-peer-port,omitempty" yaml:"bgp-peer-port,omitempty"`
+}
+
+func (c LoadBalancerConfig) GetEnabled() bool          { return util.Deref(c.Enabled) }
+func (c LoadBalancerConfig) GetCIDRs() []string        { return util.Deref(c.CIDRs) }
+func (c LoadBalancerConfig) GetL2Mode() bool           { return util.Deref(c.L2Mode) }
+func (c LoadBalancerConfig) GetL2Interfaces() []string { return util.Deref(c.L2Interfaces) }
+func (c LoadBalancerConfig) GetBGPMode() bool          { return util.Deref(c.BGPMode) }
+func (c LoadBalancerConfig) GetBGPLocalASN() int       { return util.Deref(c.BGPLocalASN) }
+func (c LoadBalancerConfig) GetBGPPeerAddress() string { return util.Deref(c.BGPPeerAddress) }
+func (c LoadBalancerConfig) GetBGPPeerASN() int        { return util.Deref(c.BGPPeerASN) }
+func (c LoadBalancerConfig) GetBGPPeerPort() int       { return util.Deref(c.BGPPeerPort) }
+
+type LocalStorageConfig struct {
+	Enabled       *bool   `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	LocalPath     *string `json:"local-path,omitempty" yaml:"local-path,omitempty"`
+	ReclaimPolicy *string `json:"reclaim-policy,omitempty" yaml:"reclaim-policy,omitempty"`
+	Default       *bool   `json:"default,omitempty" yaml:"default,omitempty"`
+}
+
+func (c LocalStorageConfig) GetEnabled() bool         { return util.Deref(c.Enabled) }
+func (c LocalStorageConfig) GetLocalPath() string     { return util.Deref(c.LocalPath) }
+func (c LocalStorageConfig) GetReclaimPolicy() string { return util.Deref(c.ReclaimPolicy) }
+func (c LocalStorageConfig) GetDefault() bool         { return util.Deref(c.Default) }
+
+type NetworkConfig struct {
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+}
+
+func (c NetworkConfig) GetEnabled() bool { return util.Deref(c.Enabled) }
+
+type GatewayConfig struct {
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+}
+
+func (c GatewayConfig) GetEnabled() bool { return util.Deref(c.Enabled) }
+
+type MetricsServerConfig struct {
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+}
+
+func (c MetricsServerConfig) GetEnabled() bool { return util.Deref(c.Enabled) }
+
+type UserFacingDatastoreConfig struct {
+	// Type of the datastore. Needs to be "external".
+	Type       *string   `json:"type,omitempty" yaml:"type,omitempty"`
+	Servers    *[]string `json:"servers,omitempty" yaml:"servers,omitempty"`
+	CACert     *string   `json:"ca-crt,omitempty" yaml:"ca-crt,omitempty"`
+	ClientCert *string   `json:"client-crt,omitempty" yaml:"client-crt,omitempty"`
+	ClientKey  *string   `json:"client-key,omitempty" yaml:"client-key,omitempty"`
+}
+
+func (c UserFacingDatastoreConfig) GetType() string       { return util.Deref(c.Type) }
+func (c UserFacingDatastoreConfig) GetServers() []string  { return util.Deref(c.Servers) }
+func (c UserFacingDatastoreConfig) GetCACert() string     { return util.Deref(c.CACert) }
+func (c UserFacingDatastoreConfig) GetClientCert() string { return util.Deref(c.ClientCert) }
+func (c UserFacingDatastoreConfig) GetClientKey() string  { return util.Deref(c.ClientKey) }
+
+func (c UserFacingClusterConfig) String() string {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Sprintf("%#v\n", c)
+	}
+	return string(b)
+}
+
+func (c NetworkConfig) String() string {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Sprintf("%#v\n", c)
+	}
+	return string(b)
+}
+
+func (c DNSConfig) String() string {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Sprintf("%#v\n", c)
+	}
+	return string(b)
+}
+
+func (c IngressConfig) String() string {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Sprintf("%#v\n", c)
+	}
+	return string(b)
+}
+
+func (c LoadBalancerConfig) String() string {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Sprintf("%#v\n", c)
+	}
+	return string(b)
+}
+
+func (c LocalStorageConfig) String() string {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Sprintf("%#v\n", c)
+	}
+	return string(b)
+}
+
+func (c GatewayConfig) String() string {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Sprintf("%#v\n", c)
+	}
+	return string(b)
+}
+
+func (c MetricsServerConfig) String() string {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Sprintf("%#v\n", c)
+	}
+	return string(b)
+}

--- a/api/v1/type_cluster_role.go
+++ b/api/v1/type_cluster_role.go
@@ -1,0 +1,11 @@
+package apiv1
+
+type ClusterRole string
+
+const (
+	ClusterRoleControlPlane ClusterRole = "control-plane"
+	ClusterRoleWorker       ClusterRole = "worker"
+	// The role of a node is unknown if it has not yet joined a cluster,
+	// currently joining or is about to leave.
+	ClusterRoleUnknown ClusterRole = "unknown"
+)

--- a/api/v1/type_cluster_status.go
+++ b/api/v1/type_cluster_status.go
@@ -1,0 +1,18 @@
+package apiv1
+
+// ClusterStatus holds information about the cluster, e.g. its current members
+type ClusterStatus struct {
+	// Ready is true if at least one node in the cluster is in READY state.
+	Ready     bool                    `json:"ready,omitempty"`
+	Members   []NodeStatus            `json:"members,omitempty"`
+	Config    UserFacingClusterConfig `json:"config,omitempty"`
+	Datastore Datastore               `json:"datastore,omitempty"`
+
+	DNS           FeatureStatus `json:"dns,omitempty" yaml:"dns,omitempty"`
+	Network       FeatureStatus `json:"network,omitempty" yaml:"network,omitempty"`
+	LoadBalancer  FeatureStatus `json:"load-balancer,omitempty" yaml:"load-balancer,omitempty"`
+	Ingress       FeatureStatus `json:"ingress,omitempty" yaml:"ingress,omitempty"`
+	Gateway       FeatureStatus `json:"gateway,omitempty" yaml:"gateway,omitempty"`
+	MetricsServer FeatureStatus `json:"metrics-server,omitempty" yaml:"metrics-server,omitempty"`
+	LocalStorage  FeatureStatus `json:"local-storage,omitempty" yaml:"local-storage,omitempty"`
+}

--- a/api/v1/type_control_plane_join_config.go
+++ b/api/v1/type_control_plane_join_config.go
@@ -1,7 +1,7 @@
 package apiv1
 
 import (
-	"github.com/canonical/k8s-snap-api-v1/internal/util"
+	"github.com/canonical/k8s-snap-api/internal/util"
 )
 
 type ControlPlaneJoinConfig struct {

--- a/api/v1/type_control_plane_join_config.go
+++ b/api/v1/type_control_plane_join_config.go
@@ -1,13 +1,10 @@
 package apiv1
 
 import (
-	"fmt"
-
 	"github.com/canonical/k8s-snap-api-v1/internal/util"
-	"gopkg.in/yaml.v2"
 )
 
-type ControlPlaneNodeJoinConfig struct {
+type ControlPlaneJoinConfig struct {
 	ExtraSANS []string `json:"extra-sans,omitempty" yaml:"extra-sans,omitempty"`
 
 	// Seed certificates for external CA
@@ -40,46 +37,37 @@ type ControlPlaneNodeJoinConfig struct {
 	ExtraNodeK8sDqliteArgs             map[string]*string `json:"extra-node-k8s-dqlite-args,omitempty" yaml:"extra-node-k8s-dqlite-args,omitempty"`
 }
 
-func (c *ControlPlaneNodeJoinConfig) GetFrontProxyClientCert() string {
+func (c *ControlPlaneJoinConfig) GetFrontProxyClientCert() string {
 	return util.Deref(c.FrontProxyClientCert)
 }
-func (c *ControlPlaneNodeJoinConfig) GetFrontProxyClientKey() string {
+func (c *ControlPlaneJoinConfig) GetFrontProxyClientKey() string {
 	return util.Deref(c.FrontProxyClientKey)
 }
-func (b *ControlPlaneNodeJoinConfig) GetKubeProxyClientCert() string {
+func (b *ControlPlaneJoinConfig) GetKubeProxyClientCert() string {
 	return util.Deref(b.KubeProxyClientCert)
 }
-func (b *ControlPlaneNodeJoinConfig) GetKubeProxyClientKey() string {
+func (b *ControlPlaneJoinConfig) GetKubeProxyClientKey() string {
 	return util.Deref(b.KubeProxyClientKey)
 }
-func (b *ControlPlaneNodeJoinConfig) GetKubeSchedulerClientCert() string {
+func (b *ControlPlaneJoinConfig) GetKubeSchedulerClientCert() string {
 	return util.Deref(b.KubeSchedulerClientCert)
 }
-func (b *ControlPlaneNodeJoinConfig) GetKubeSchedulerClientKey() string {
+func (b *ControlPlaneJoinConfig) GetKubeSchedulerClientKey() string {
 	return util.Deref(b.KubeSchedulerClientKey)
 }
-func (b *ControlPlaneNodeJoinConfig) GetKubeControllerManagerClientCert() string {
+func (b *ControlPlaneJoinConfig) GetKubeControllerManagerClientCert() string {
 	return util.Deref(b.KubeControllerManagerClientCert)
 }
-func (b *ControlPlaneNodeJoinConfig) GetKubeControllerManagerClientKey() string {
+func (b *ControlPlaneJoinConfig) GetKubeControllerManagerClientKey() string {
 	return util.Deref(b.KubeControllerManagerClientKey)
 }
-func (c *ControlPlaneNodeJoinConfig) GetAPIServerCert() string { return util.Deref(c.APIServerCert) }
-func (c *ControlPlaneNodeJoinConfig) GetAPIServerKey() string  { return util.Deref(c.APIServerKey) }
-func (c *ControlPlaneNodeJoinConfig) GetKubeletCert() string   { return util.Deref(c.KubeletCert) }
-func (c *ControlPlaneNodeJoinConfig) GetKubeletKey() string    { return util.Deref(c.KubeletKey) }
-func (c *ControlPlaneNodeJoinConfig) GetKubeletClientCert() string {
+func (c *ControlPlaneJoinConfig) GetAPIServerCert() string { return util.Deref(c.APIServerCert) }
+func (c *ControlPlaneJoinConfig) GetAPIServerKey() string  { return util.Deref(c.APIServerKey) }
+func (c *ControlPlaneJoinConfig) GetKubeletCert() string   { return util.Deref(c.KubeletCert) }
+func (c *ControlPlaneJoinConfig) GetKubeletKey() string    { return util.Deref(c.KubeletKey) }
+func (c *ControlPlaneJoinConfig) GetKubeletClientCert() string {
 	return util.Deref(c.KubeletClientCert)
 }
-func (c *ControlPlaneNodeJoinConfig) GetKubeletClientKey() string {
+func (c *ControlPlaneJoinConfig) GetKubeletClientKey() string {
 	return util.Deref(c.KubeletClientKey)
-}
-
-// WorkerJoinConfigFromMicrocluster parses a microcluster map[string]string and retrieves the WorkerNodeJoinConfig.
-func ControlPlaneJoinConfigFromMicrocluster(m map[string]string) (ControlPlaneNodeJoinConfig, error) {
-	config := ControlPlaneNodeJoinConfig{}
-	if err := yaml.UnmarshalStrict([]byte(m["controlPlaneJoinConfig"]), &config); err != nil {
-		return ControlPlaneNodeJoinConfig{}, fmt.Errorf("failed to unmarshal control plane join config: %w", err)
-	}
-	return config, nil
 }

--- a/api/v1/type_control_plane_node_join_config.go
+++ b/api/v1/type_control_plane_node_join_config.go
@@ -3,7 +3,7 @@ package apiv1
 import (
 	"fmt"
 
-	"github.com/canonical/k8s-snap-api/internal/util"
+	"github.com/canonical/k8s-snap-api-v1/internal/util"
 	"gopkg.in/yaml.v2"
 )
 
@@ -74,7 +74,6 @@ func (c *ControlPlaneNodeJoinConfig) GetKubeletClientCert() string {
 func (c *ControlPlaneNodeJoinConfig) GetKubeletClientKey() string {
 	return util.Deref(c.KubeletClientKey)
 }
-
 
 // WorkerJoinConfigFromMicrocluster parses a microcluster map[string]string and retrieves the WorkerNodeJoinConfig.
 func ControlPlaneJoinConfigFromMicrocluster(m map[string]string) (ControlPlaneNodeJoinConfig, error) {

--- a/api/v1/type_control_plane_node_join_config.go
+++ b/api/v1/type_control_plane_node_join_config.go
@@ -1,0 +1,86 @@
+package apiv1
+
+import (
+	"fmt"
+
+	"github.com/canonical/k8s-snap-api/internal/util"
+	"gopkg.in/yaml.v2"
+)
+
+type ControlPlaneNodeJoinConfig struct {
+	ExtraSANS []string `json:"extra-sans,omitempty" yaml:"extra-sans,omitempty"`
+
+	// Seed certificates for external CA
+	FrontProxyClientCert            *string `json:"front-proxy-client-crt,omitempty" yaml:"front-proxy-client-crt,omitempty"`
+	FrontProxyClientKey             *string `json:"front-proxy-client-key,omitempty" yaml:"front-proxy-client-key,omitempty"`
+	KubeProxyClientCert             *string `json:"kube-proxy-client-crt,omitempty" yaml:"kube-proxy-client-crt,omitempty"`
+	KubeProxyClientKey              *string `json:"kube-proxy-client-key,omitempty" yaml:"kube-proxy-client-key,omitempty"`
+	KubeSchedulerClientCert         *string `json:"kube-scheduler-client-crt,omitempty" yaml:"kube-scheduler-client-crt,omitempty"`
+	KubeSchedulerClientKey          *string `json:"kube-scheduler-client-key,omitempty" yaml:"kube-scheduler-client-key,omitempty"`
+	KubeControllerManagerClientCert *string `json:"kube-controller-manager-client-crt,omitempty" yaml:"kube-controller-manager-client-crt,omitempty"`
+	KubeControllerManagerClientKey  *string `json:"kube-controller-manager-client-key,omitempty" yaml:"kube-ControllerManager-client-key,omitempty"`
+
+	APIServerCert     *string `json:"apiserver-crt,omitempty" yaml:"apiserver-crt,omitempty"`
+	APIServerKey      *string `json:"apiserver-key,omitempty" yaml:"apiserver-key,omitempty"`
+	KubeletCert       *string `json:"kubelet-crt,omitempty" yaml:"kubelet-crt,omitempty"`
+	KubeletKey        *string `json:"kubelet-key,omitempty" yaml:"kubelet-key,omitempty"`
+	KubeletClientCert *string `json:"kubelet-client-crt,omitempty" yaml:"kubelet-client-crt,omitempty"`
+	KubeletClientKey  *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
+
+	// ExtraNodeConfigFiles will be written to /var/snap/k8s/common/args/conf.d
+	ExtraNodeConfigFiles map[string]string `json:"extra-node-config-files,omitempty" yaml:"extra-node-config-files,omitempty"`
+
+	// Extra args to add to individual services (set any arg to null to delete)
+	ExtraNodeKubeAPIServerArgs         map[string]*string `json:"extra-node-kube-apiserver-args,omitempty" yaml:"extra-node-kube-apiserver-args,omitempty"`
+	ExtraNodeKubeControllerManagerArgs map[string]*string `json:"extra-node-kube-controller-manager-args,omitempty" yaml:"extra-node-kube-controller-manager-args,omitempty"`
+	ExtraNodeKubeSchedulerArgs         map[string]*string `json:"extra-node-kube-scheduler-args,omitempty" yaml:"extra-node-kube-scheduler-args,omitempty"`
+	ExtraNodeKubeProxyArgs             map[string]*string `json:"extra-node-kube-proxy-args,omitempty" yaml:"extra-node-kube-proxy-args,omitempty"`
+	ExtraNodeKubeletArgs               map[string]*string `json:"extra-node-kubelet-args,omitempty" yaml:"extra-node-kubelet-args,omitempty"`
+	ExtraNodeContainerdArgs            map[string]*string `json:"extra-node-containerd-args,omitempty" yaml:"extra-node-containerd-args,omitempty"`
+	ExtraNodeK8sDqliteArgs             map[string]*string `json:"extra-node-k8s-dqlite-args,omitempty" yaml:"extra-node-k8s-dqlite-args,omitempty"`
+}
+
+func (c *ControlPlaneNodeJoinConfig) GetFrontProxyClientCert() string {
+	return util.Deref(c.FrontProxyClientCert)
+}
+func (c *ControlPlaneNodeJoinConfig) GetFrontProxyClientKey() string {
+	return util.Deref(c.FrontProxyClientKey)
+}
+func (b *ControlPlaneNodeJoinConfig) GetKubeProxyClientCert() string {
+	return util.Deref(b.KubeProxyClientCert)
+}
+func (b *ControlPlaneNodeJoinConfig) GetKubeProxyClientKey() string {
+	return util.Deref(b.KubeProxyClientKey)
+}
+func (b *ControlPlaneNodeJoinConfig) GetKubeSchedulerClientCert() string {
+	return util.Deref(b.KubeSchedulerClientCert)
+}
+func (b *ControlPlaneNodeJoinConfig) GetKubeSchedulerClientKey() string {
+	return util.Deref(b.KubeSchedulerClientKey)
+}
+func (b *ControlPlaneNodeJoinConfig) GetKubeControllerManagerClientCert() string {
+	return util.Deref(b.KubeControllerManagerClientCert)
+}
+func (b *ControlPlaneNodeJoinConfig) GetKubeControllerManagerClientKey() string {
+	return util.Deref(b.KubeControllerManagerClientKey)
+}
+func (c *ControlPlaneNodeJoinConfig) GetAPIServerCert() string { return util.Deref(c.APIServerCert) }
+func (c *ControlPlaneNodeJoinConfig) GetAPIServerKey() string  { return util.Deref(c.APIServerKey) }
+func (c *ControlPlaneNodeJoinConfig) GetKubeletCert() string   { return util.Deref(c.KubeletCert) }
+func (c *ControlPlaneNodeJoinConfig) GetKubeletKey() string    { return util.Deref(c.KubeletKey) }
+func (c *ControlPlaneNodeJoinConfig) GetKubeletClientCert() string {
+	return util.Deref(c.KubeletClientCert)
+}
+func (c *ControlPlaneNodeJoinConfig) GetKubeletClientKey() string {
+	return util.Deref(c.KubeletClientKey)
+}
+
+
+// WorkerJoinConfigFromMicrocluster parses a microcluster map[string]string and retrieves the WorkerNodeJoinConfig.
+func ControlPlaneJoinConfigFromMicrocluster(m map[string]string) (ControlPlaneNodeJoinConfig, error) {
+	config := ControlPlaneNodeJoinConfig{}
+	if err := yaml.UnmarshalStrict([]byte(m["controlPlaneJoinConfig"]), &config); err != nil {
+		return ControlPlaneNodeJoinConfig{}, fmt.Errorf("failed to unmarshal control plane join config: %w", err)
+	}
+	return config, nil
+}

--- a/api/v1/type_datastore.go
+++ b/api/v1/type_datastore.go
@@ -1,0 +1,6 @@
+package apiv1
+
+type Datastore struct {
+	Type    string   `json:"type,omitempty"`
+	Servers []string `json:"servers,omitempty" yaml:"servers,omitempty"`
+}

--- a/api/v1/type_datastore_role.go
+++ b/api/v1/type_datastore_role.go
@@ -1,0 +1,12 @@
+package apiv1
+
+// DatastoreRole as provided by dqlite
+type DatastoreRole string
+
+const (
+	DatastoreRoleVoter   DatastoreRole = "voter"
+	DatastoreRoleStandBy DatastoreRole = "stand-by"
+	DatastoreRoleSpare   DatastoreRole = "spare"
+	DatastoreRolePending DatastoreRole = "PENDING"
+	DatastoreRoleUnknown DatastoreRole = "unknown"
+)

--- a/api/v1/type_feature_status.go
+++ b/api/v1/type_feature_status.go
@@ -1,0 +1,25 @@
+package apiv1
+
+import "time"
+
+// FeatureStatus encapsulates the deployment status of a feature.
+type FeatureStatus struct {
+	// Enabled shows whether or not the deployment of manifests for a status was successful.
+	Enabled bool `json:"enabled" yaml:"enabled"`
+	// Message contains information about the status of a feature. It is only supposed to be human readable and informative and should not be programmatically parsed.
+	Message string `json:"message" yaml:"message"`
+	// Version shows the version of the deployed feature.
+	Version string `json:"version" yaml:"version"`
+	// UpdatedAt shows when the last update was done.
+	UpdatedAt time.Time `json:"updated-at" yaml:"updated-at"`
+}
+
+func (f FeatureStatus) String() string {
+	if f.Message != "" {
+		return f.Message
+	}
+	if f.Enabled {
+		return "enabled"
+	}
+	return "disabled"
+}

--- a/api/v1/type_kubernetes_token_review.go
+++ b/api/v1/type_kubernetes_token_review.go
@@ -1,0 +1,39 @@
+package apiv1
+
+// TokenReviewRequest is the request for "POST 1.0/kubernetes/auth/webhook".
+// This mirrors the definition of the Kubernetes API group="authentication.k8s.io/v1" kind="TokenReview"
+// https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/
+type TokenReview struct {
+	APIVersion string            `json:"apiVersion"`
+	Kind       string            `json:"kind"`
+	Spec       TokenReviewSpec   `json:"spec"`
+	Status     TokenReviewStatus `json:"status"`
+}
+
+// TokenReviewSpec is set by kube-apiserver in TokenReview.
+// This mirrors the definition of the Kubernetes API group="authentication.k8s.io/v1" kind="TokenReview"
+// https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/#TokenReviewSpec
+type TokenReviewSpec struct {
+	Audiences []string `json:"audiences,omitempty"`
+	Token     string   `json:"token"`
+}
+
+// TokenReviewStatus is set by the webhook server in TokenReview.
+// This mirrors the definition of the Kubernetes API group="authentication.k8s.io/v1" kind="TokenReview"
+// https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/#TokenReviewStatus
+type TokenReviewStatus struct {
+	Audiences     []string                  `json:"audiences,omitempty"`
+	Authenticated bool                      `json:"authenticated"`
+	Error         string                    `json:"error,omitempty"`
+	User          TokenReviewStatusUserInfo `json:"user,omitempty"`
+}
+
+// TokenReviewStatusUserInfo is set by the webhook server in TokenReview.
+// This mirrors the definition of the Kubernetes API group="authentication.k8s.io/v1" kind="TokenReview"
+// https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/#TokenReviewStatus
+type TokenReviewStatusUserInfo struct {
+	Extra    map[string][]string `json:"extra,omitempty"`
+	Groups   []string            `json:"groups,omitempty"`
+	Username string              `json:"username,omitempty"`
+	UID      string              `json:"uid,omitempty"`
+}

--- a/api/v1/type_node_status.go
+++ b/api/v1/type_node_status.go
@@ -1,0 +1,15 @@
+package apiv1
+
+// NodeStatus holds information about a node in the k8s cluster.
+type NodeStatus struct {
+	// Name is the name for this cluster member that was when joining the cluster.
+	// This is typically the hostname of the node.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// Address is the IP address of the node.
+	Address string `json:"address,omitempty" yaml:"address,omitempty"`
+	// ClusterRole is the role that the node has within the k8s cluster.
+	ClusterRole ClusterRole `json:"cluster-role,omitempty" yaml:"cluster-role,omitempty"`
+	// DatastoreRole is the role that the node has within the datastore cluster.
+	// Only applicable for control-plane nodes, empty for workers.
+	DatastoreRole DatastoreRole `json:"datastore-role,omitempty" yaml:"datastore-role,omitempty"`
+}

--- a/api/v1/type_worker_node_join_config.go
+++ b/api/v1/type_worker_node_join_config.go
@@ -3,7 +3,7 @@ package apiv1
 import (
 	"fmt"
 
-	"github.com/canonical/k8s-snap-api/internal/util"
+	"github.com/canonical/k8s-snap-api-v1/internal/util"
 	"gopkg.in/yaml.v2"
 )
 

--- a/api/v1/type_worker_node_join_config.go
+++ b/api/v1/type_worker_node_join_config.go
@@ -1,6 +1,6 @@
 package apiv1
 
-import "github.com/canonical/k8s-snap-api-v1/internal/util"
+import "github.com/canonical/k8s-snap-api/internal/util"
 
 type WorkerJoinConfig struct {
 	KubeletCert         *string `json:"kubelet-crt,omitempty" yaml:"kubelet-crt,omitempty"`

--- a/api/v1/type_worker_node_join_config.go
+++ b/api/v1/type_worker_node_join_config.go
@@ -1,0 +1,46 @@
+package apiv1
+
+import (
+	"fmt"
+
+	"github.com/canonical/k8s-snap-api/internal/util"
+	"gopkg.in/yaml.v2"
+)
+
+type WorkerNodeJoinConfig struct {
+	KubeletCert         *string `json:"kubelet-crt,omitempty" yaml:"kubelet-crt,omitempty"`
+	KubeletKey          *string `json:"kubelet-key,omitempty" yaml:"kubelet-key,omitempty"`
+	KubeletClientCert   *string `json:"kubelet-client-crt,omitempty" yaml:"kubelet-client-crt,omitempty"`
+	KubeletClientKey    *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
+	KubeProxyClientCert *string `json:"kube-proxy-client-crt,omitempty" yaml:"kube-proxy-client-crt,omitempty"`
+	KubeProxyClientKey  *string `json:"kube-proxy-client-key,omitempty" yaml:"kube-proxy-client-key,omitempty"`
+
+	// ExtraNodeConfigFiles will be written to /var/snap/k8s/common/args/conf.d
+	ExtraNodeConfigFiles map[string]string `json:"extra-node-config-files,omitempty" yaml:"extra-node-config-files,omitempty"`
+
+	// Extra args to add to individual services (set any arg to null to delete)
+	ExtraNodeKubeProxyArgs         map[string]*string `json:"extra-node-kube-proxy-args,omitempty" yaml:"extra-node-kube-proxy-args,omitempty"`
+	ExtraNodeKubeletArgs           map[string]*string `json:"extra-node-kubelet-args,omitempty" yaml:"extra-node-kubelet-args,omitempty"`
+	ExtraNodeContainerdArgs        map[string]*string `json:"extra-node-containerd-args,omitempty" yaml:"extra-node-containerd-args,omitempty"`
+	ExtraNodeK8sAPIServerProxyArgs map[string]*string `json:"extra-node-k8s-apiserver-proxy-args,omitempty" yaml:"extra-node-k8s-apiserver-proxy-args,omitempty"`
+}
+
+func (w *WorkerNodeJoinConfig) GetKubeletCert() string       { return util.Deref(w.KubeletCert) }
+func (w *WorkerNodeJoinConfig) GetKubeletKey() string        { return util.Deref(w.KubeletKey) }
+func (w *WorkerNodeJoinConfig) GetKubeletClientCert() string { return util.Deref(w.KubeletClientCert) }
+func (w *WorkerNodeJoinConfig) GetKubeletClientKey() string  { return util.Deref(w.KubeletClientKey) }
+func (w *WorkerNodeJoinConfig) GetKubeProxyClientCert() string {
+	return util.Deref(w.KubeProxyClientCert)
+}
+func (w *WorkerNodeJoinConfig) GetKubeProxyClientKey() string {
+	return util.Deref(w.KubeProxyClientKey)
+}
+
+// WorkerJoinConfigFromMicrocluster parses a microcluster map[string]string and retrieves the WorkerNodeJoinConfig.
+func WorkerJoinConfigFromMicrocluster(m map[string]string) (WorkerNodeJoinConfig, error) {
+	config := WorkerNodeJoinConfig{}
+	if err := yaml.UnmarshalStrict([]byte(m["workerJoinConfig"]), &config); err != nil {
+		return WorkerNodeJoinConfig{}, fmt.Errorf("failed to unmarshal worker join config: %w", err)
+	}
+	return config, nil
+}

--- a/api/v1/type_worker_node_join_config.go
+++ b/api/v1/type_worker_node_join_config.go
@@ -1,13 +1,8 @@
 package apiv1
 
-import (
-	"fmt"
+import "github.com/canonical/k8s-snap-api-v1/internal/util"
 
-	"github.com/canonical/k8s-snap-api-v1/internal/util"
-	"gopkg.in/yaml.v2"
-)
-
-type WorkerNodeJoinConfig struct {
+type WorkerJoinConfig struct {
 	KubeletCert         *string `json:"kubelet-crt,omitempty" yaml:"kubelet-crt,omitempty"`
 	KubeletKey          *string `json:"kubelet-key,omitempty" yaml:"kubelet-key,omitempty"`
 	KubeletClientCert   *string `json:"kubelet-client-crt,omitempty" yaml:"kubelet-client-crt,omitempty"`
@@ -25,22 +20,13 @@ type WorkerNodeJoinConfig struct {
 	ExtraNodeK8sAPIServerProxyArgs map[string]*string `json:"extra-node-k8s-apiserver-proxy-args,omitempty" yaml:"extra-node-k8s-apiserver-proxy-args,omitempty"`
 }
 
-func (w *WorkerNodeJoinConfig) GetKubeletCert() string       { return util.Deref(w.KubeletCert) }
-func (w *WorkerNodeJoinConfig) GetKubeletKey() string        { return util.Deref(w.KubeletKey) }
-func (w *WorkerNodeJoinConfig) GetKubeletClientCert() string { return util.Deref(w.KubeletClientCert) }
-func (w *WorkerNodeJoinConfig) GetKubeletClientKey() string  { return util.Deref(w.KubeletClientKey) }
-func (w *WorkerNodeJoinConfig) GetKubeProxyClientCert() string {
+func (w *WorkerJoinConfig) GetKubeletCert() string       { return util.Deref(w.KubeletCert) }
+func (w *WorkerJoinConfig) GetKubeletKey() string        { return util.Deref(w.KubeletKey) }
+func (w *WorkerJoinConfig) GetKubeletClientCert() string { return util.Deref(w.KubeletClientCert) }
+func (w *WorkerJoinConfig) GetKubeletClientKey() string  { return util.Deref(w.KubeletClientKey) }
+func (w *WorkerJoinConfig) GetKubeProxyClientCert() string {
 	return util.Deref(w.KubeProxyClientCert)
 }
-func (w *WorkerNodeJoinConfig) GetKubeProxyClientKey() string {
+func (w *WorkerJoinConfig) GetKubeProxyClientKey() string {
 	return util.Deref(w.KubeProxyClientKey)
-}
-
-// WorkerJoinConfigFromMicrocluster parses a microcluster map[string]string and retrieves the WorkerNodeJoinConfig.
-func WorkerJoinConfigFromMicrocluster(m map[string]string) (WorkerNodeJoinConfig, error) {
-	config := WorkerNodeJoinConfig{}
-	if err := yaml.UnmarshalStrict([]byte(m["workerJoinConfig"]), &config); err != nil {
-		return WorkerNodeJoinConfig{}, fmt.Errorf("failed to unmarshal worker join config: %w", err)
-	}
-	return config, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/canonical/k8s-snap-api
+
+go 1.22.6
+
+require gopkg.in/yaml.v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/canonical/k8s-snap-api
+module github.com/canonical/k8s-snap-api-v1
 
 go 1.22.6
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/canonical/k8s-snap-api-v1
+module github.com/canonical/k8s-snap-api
 
 go 1.22.6
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/internal/util/ptr.go
+++ b/internal/util/ptr.go
@@ -1,0 +1,15 @@
+package util
+
+// Deref returns the concrete value of a pointer, or the zero value for that type.
+func Deref[T any](ptr *T) T {
+	if ptr != nil {
+		return *ptr
+	}
+	var zero T
+	return zero
+}
+
+// PtrTo returns a pointer to a concrete value.
+func PtrTo[T any](val T) *T {
+	return &val
+}


### PR DESCRIPTION
### Summary

Add API definitions as used in Canonical Kubernetes https://github.com/canonical/k8s-snap/tree/1b5e0852b36959ecd6319df9c8bce5b216cc6b29/src/k8s/api/v1

### Notes

- Types are defined in `type_$typename.go`
- RPC are defined in `rpc_$rpcname.go`
- All RPCs define their path, request message and response message.

### Review notes

- microcluster specific functions are not part of the API, they will be moved to k8s-snap repo.
- cluster status formatting is not part of the API, it will be moved to k8s-snap repo