### PR TITLE
Add TTL to GetJoinTokenRequest

### DIFF
--- a/api/v1/rpc_get_join_token.go
+++ b/api/v1/rpc_get_join_token.go
@@ -1,5 +1,7 @@
 package apiv1
 
+import "time"
+
 // GetJoinTokenRPC is the path for the GetJoinToken RPC.
 const GetJoinTokenRPC = "k8sd/cluster/tokens"
 
@@ -9,6 +11,8 @@ type GetJoinTokenRequest struct {
 	Name string `json:"name"`
 	// Worker should be set to true to generate a token for joining a worker node.
 	Worker bool `json:"worker"`
+	// TTL is the duration until the token expires (time-to-live).
+	TTL time.Duration `json:"ttl,omitempty"`
 }
 
 // GetJoinTokenResponse is the response message for the GetJoinToken RPC.


### PR DESCRIPTION
Add the TTL duration as a parameter to the join token request. 
An empty TTL is omitted which makes this a backward-compatible change and will only bump the `patch` version of the API