### PR TITLE
Add skip services stop annotation

### DIFF
--- a/api/v1/const.go
+++ b/api/v1/const.go
@@ -8,4 +8,9 @@ const (
 	// This is useful, if an external controller (e.g. CAPI) is responsible for the Kubernetes node life cycle.
 	// By default, the Kubernetes node is removed by k8sd if a node is removed from the cluster.
 	AnnotationSkipCleanupKubernetesNodeOnRemove = "k8sd/v1alpha/lifecycle/skip-cleanup-kubernetes-node-on-remove"
+
+	// AnnotationSkipStopServicesOnRemove if set, the k8s services will not be stopped on the leaving node when removing the node.
+	// This is useful, if an external controller (e.g. CAPI) is responsible for the Kubernetes node life cycle.
+	// By default, all services are stopped on leaving nodes.
+	AnnotationSkipStopServicesOnRemove = "k8sd/v1alpha/lifecycle/skip-stop-services-on-remove"
 )

--- a/api/v1/rpc_get_worker_join_info.go
+++ b/api/v1/rpc_get_worker_join_info.go
@@ -41,4 +41,6 @@ type GetWorkerJoinInfoResponse struct {
 	KubeletKey string `json:"kubeletKey,omitempty"`
 	// K8sdPublicKey is the public key that can be used to validate authenticity of cluster messages.
 	K8sdPublicKey string `json:"k8sdPublicKey,omitempty"`
+	// Annotations is a map of strings that can be used to store arbitrary metadata configuration.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }


### PR DESCRIPTION
If the annotation is set, the Kubernetes services on a node that is leaving the cluster are not stopped. Required for CAPI node draining. 

Also, adds the Annotations to the worker info response to propagate this annotation to worker nodes.

Will create a new release once this is merged.