### PR TITLE
Add field docstrings, to be used by doc automation

### DIFF
--- a/api/v1/rpc_get_worker_join_info.go
+++ b/api/v1/rpc_get_worker_join_info.go
@@ -42,5 +42,6 @@ type GetWorkerJoinInfoResponse struct {
 	// K8sdPublicKey is the public key that can be used to validate authenticity of cluster messages.
 	K8sdPublicKey string `json:"k8sdPublicKey,omitempty"`
 	// Annotations is a map of strings that can be used to store arbitrary metadata configuration.
+	// Please refer to the ClusterAPI annotations reference for further details on these options.
 	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/api/v1/type_bootstrap_config.go
+++ b/api/v1/type_bootstrap_config.go
@@ -5,34 +5,77 @@ import "github.com/canonical/k8s-snap-api/internal/util"
 // BootstrapConfig is used to seed cluster configuration when bootstrapping a new cluster.
 type BootstrapConfig struct {
 	// ClusterConfig
+
 	ClusterConfig UserFacingClusterConfig `json:"cluster-config,omitempty" yaml:"cluster-config,omitempty"`
 
 	// Seed configuration for the control plane (flat on purpose). Empty values are ignored
+
+	// List of taints to be applied to control plane nodes.
 	ControlPlaneTaints  []string `json:"control-plane-taints,omitempty" yaml:"control-plane-taints,omitempty"`
+	// The CIDR to be used for assigning pod addresses.
+	// If omitted defaults to `10.1.0.0/16`.
 	PodCIDR             *string  `json:"pod-cidr,omitempty" yaml:"pod-cidr,omitempty"`
+	// The CIDR to be used for assigning service addresses.
+	// If omitted defaults to `10.152.183.0/24`.
 	ServiceCIDR         *string  `json:"service-cidr,omitempty" yaml:"service-cidr,omitempty"`
+	// Determines if RBAC should be disabled.
+	// If omitted defaults to `false`.
 	DisableRBAC         *bool    `json:"disable-rbac,omitempty" yaml:"disable-rbac,omitempty"`
+	// The port number for kube-apiserver to use.
+	// If omitted defaults to `6443`.
 	SecurePort          *int     `json:"secure-port,omitempty" yaml:"secure-port,omitempty"`
+	// The port number for k8s-dqlite to use.
+	// If omitted defaults to `9000`.
 	K8sDqlitePort       *int     `json:"k8s-dqlite-port,omitempty" yaml:"k8s-dqlite-port,omitempty"`
+	// The type of datastore to be used.
+	// If omitted defaults to `k8s-dqlite`.
+	//
+	// Can be used to point to an external datastore like etcd.
+	//
+	// Possible Values: `k8s-dqlite | external`.
 	DatastoreType       *string  `json:"datastore-type,omitempty" yaml:"datastore-type,omitempty"`
+	// The server addresses to be used when `datastore-type` is set to `external`.
 	DatastoreServers    []string `json:"datastore-servers,omitempty" yaml:"datastore-servers,omitempty"`
+	// The CA certificate to be used when communicating with the external datastore.
 	DatastoreCACert     *string  `json:"datastore-ca-crt,omitempty" yaml:"datastore-ca-crt,omitempty"`
+	// The client certificate to be used when communicating with the external
+	// datastore.
 	DatastoreClientCert *string  `json:"datastore-client-crt,omitempty" yaml:"datastore-client-crt,omitempty"`
+	// The client key to be used when communicating with the external datastore.
 	DatastoreClientKey  *string  `json:"datastore-client-key,omitempty" yaml:"datastore-client-key,omitempty"`
 
 	// Seed configuration for certificates
+
+	// List of extra SANs to be added to certificates.
 	ExtraSANs []string `json:"extra-sans,omitempty" yaml:"extra-sans,omitempty"`
 
 	// Seed configuration for external certificates (cluster-wide)
+
+	// The CA certificate to be used for Kubernetes services.
+	// If omitted defaults to an auto generated certificate.
 	CACert                          *string `json:"ca-crt,omitempty" yaml:"ca-crt,omitempty"`
+	// The CA key to be used for Kubernetes services.
+	// If omitted defaults to an auto generated key.
 	CAKey                           *string `json:"ca-key,omitempty" yaml:"ca-key,omitempty"`
 	ClientCACert                    *string `json:"client-ca-crt,omitempty" yaml:"client-ca-crt,omitempty"`
 	ClientCAKey                     *string `json:"client-ca-key,omitempty" yaml:"client-ca-key,omitempty"`
+	// The CA certificate to be used for the front proxy.
+	// If omitted defaults to an auto generated certificate.
 	FrontProxyCACert                *string `json:"front-proxy-ca-crt,omitempty" yaml:"front-proxy-ca-crt,omitempty"`
+	// The CA key to be used for the front proxy.
+	// If omitted defaults to an auto generated key.
 	FrontProxyCAKey                 *string `json:"front-proxy-ca-key,omitempty" yaml:"front-proxy-ca-key,omitempty"`
+	// The client certificate to be used for the front proxy.
+	// If omitted defaults to an auto generated certificate.
 	FrontProxyClientCert            *string `json:"front-proxy-client-crt,omitempty" yaml:"front-proxy-client-crt,omitempty"`
+	// The client key to be used for the front proxy.
+	// If omitted defaults to an auto generated key.
 	FrontProxyClientKey             *string `json:"front-proxy-client-key,omitempty" yaml:"front-proxy-client-key,omitempty"`
+	// The client certificate to be used by kubelet for communicating with the kube-apiserver.
+	// If omitted defaults to an auto generated certificate.
 	APIServerKubeletClientCert      *string `json:"apiserver-kubelet-client-crt,omitempty" yaml:"apiserver-kubelet-client-crt,omitempty"`
+	// The client key to be used by kubelet for communicating with the kube-apiserver.
+	// If omitted defaults to an auto generated key.
 	APIServerKubeletClientKey       *string `json:"apiserver-kubelet-client-key,omitempty" yaml:"apiserver-kubelet-client-key,omitempty"`
 	AdminClientCert                 *string `json:"admin-client-crt,omitempty" yaml:"admin-client-crt,omitempty"`
 	AdminClientKey                  *string `json:"admin-client-key,omitempty" yaml:"admin-client-key,omitempty"`
@@ -42,26 +85,63 @@ type BootstrapConfig struct {
 	KubeSchedulerClientKey          *string `json:"kube-scheduler-client-key,omitempty" yaml:"kube-scheduler-client-key,omitempty"`
 	KubeControllerManagerClientCert *string `json:"kube-controller-manager-client-crt,omitempty" yaml:"kube-controller-manager-client-crt,omitempty"`
 	KubeControllerManagerClientKey  *string `json:"kube-controller-manager-client-key,omitempty" yaml:"kube-ControllerManager-client-key,omitempty"`
+	// The key to be used by the default service account.
+	// If omitted defaults to an auto generated key.
 	ServiceAccountKey               *string `json:"service-account-key,omitempty" yaml:"service-account-key,omitempty"`
 
 	// Seed configuration for external certificates (node-specific)
+
+	// The certificate to be used for the kube-apiserver.
+	// If omitted defaults to an auto generated certificate.
 	APIServerCert     *string `json:"apiserver-crt,omitempty" yaml:"apiserver-crt,omitempty"`
+	// The key to be used for the kube-apiserver.
+	// If omitted defaults to an auto generated key.
 	APIServerKey      *string `json:"apiserver-key,omitempty" yaml:"apiserver-key,omitempty"`
+	// The certificate to be used for the kubelet.
+	// If omitted defaults to an auto generated certificate.
 	KubeletCert       *string `json:"kubelet-crt,omitempty" yaml:"kubelet-crt,omitempty"`
+	// The key to be used for the kubelet.
+	// If omitted defaults to an auto generated key.
 	KubeletKey        *string `json:"kubelet-key,omitempty" yaml:"kubelet-key,omitempty"`
 	KubeletClientCert *string `json:"kubelet-client-crt,omitempty" yaml:"kubelet-client-crt,omitempty"`
 	KubeletClientKey  *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
 
-	// ExtraNodeConfigFiles will be written to /var/snap/k8s/common/args/conf.d
+	// Additional files that are uploaded `/var/snap/k8s/common/args/conf.d/<filename>`
+	// to a node on bootstrap. These files can then be referenced by Kubernetes
+	// service arguments.
+	//
+	// The format is `map[<filename>]<filecontent>`.
 	ExtraNodeConfigFiles map[string]string `json:"extra-node-config-files,omitempty" yaml:"extra-node-config-files,omitempty"`
 
-	// Extra args to add to individual services (set any arg to null to delete)
+	// Extra args to add to individual services (set any arg to null to delete).
+
+	// Additional arguments that are passed to the `kube-apiserver` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeAPIServerArgs         map[string]*string `json:"extra-node-kube-apiserver-args,omitempty" yaml:"extra-node-kube-apiserver-args,omitempty"`
+	// Additional arguments that are passed to the `kube-controller-manager` only for
+	// that specific node. Overwrites default configuration. A parameter that is
+	// explicitly set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeControllerManagerArgs map[string]*string `json:"extra-node-kube-controller-manager-args,omitempty" yaml:"extra-node-kube-controller-manager-args,omitempty"`
+	// Additional arguments that are passed to the `kube-scheduler` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeSchedulerArgs         map[string]*string `json:"extra-node-kube-scheduler-args,omitempty" yaml:"extra-node-kube-scheduler-args,omitempty"`
+	// Additional arguments that are passed to the `kube-proxy` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeProxyArgs             map[string]*string `json:"extra-node-kube-proxy-args,omitempty" yaml:"extra-node-kube-proxy-args,omitempty"`
+	// Additional arguments that are passed to the `kubelet` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeletArgs               map[string]*string `json:"extra-node-kubelet-args,omitempty" yaml:"extra-node-kubelet-args,omitempty"`
+	// Additional arguments that are passed to `containerd` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeContainerdArgs            map[string]*string `json:"extra-node-containerd-args,omitempty" yaml:"extra-node-containerd-args,omitempty"`
+	// Additional arguments that are passed to `k8s-dqlite` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeK8sDqliteArgs             map[string]*string `json:"extra-node-k8s-dqlite-args,omitempty" yaml:"extra-node-k8s-dqlite-args,omitempty"`
 
 	// Extra configuration for the containerd config.toml

--- a/api/v1/type_bootstrap_config.go
+++ b/api/v1/type_bootstrap_config.go
@@ -57,7 +57,11 @@ type BootstrapConfig struct {
 	// The CA key to be used for Kubernetes services.
 	// If omitted defaults to an auto generated key.
 	CAKey                           *string `json:"ca-key,omitempty" yaml:"ca-key,omitempty"`
+	// The client CA certificate to be used for Kubernetes services.
+	// If omitted defaults to an auto generated certificate.
 	ClientCACert                    *string `json:"client-ca-crt,omitempty" yaml:"client-ca-crt,omitempty"`
+	// The client CA key to be used for Kubernetes services.
+	// If omitted defaults to an auto generated key.
 	ClientCAKey                     *string `json:"client-ca-key,omitempty" yaml:"client-ca-key,omitempty"`
 	// The CA certificate to be used for the front proxy.
 	// If omitted defaults to an auto generated certificate.
@@ -77,13 +81,30 @@ type BootstrapConfig struct {
 	// The client key to be used by kubelet for communicating with the kube-apiserver.
 	// If omitted defaults to an auto generated key.
 	APIServerKubeletClientKey       *string `json:"apiserver-kubelet-client-key,omitempty" yaml:"apiserver-kubelet-client-key,omitempty"`
+
+	// The admin client certificate to be used for Kubernetes services.
+	// If omitted defaults to an auto generated certificate.
 	AdminClientCert                 *string `json:"admin-client-crt,omitempty" yaml:"admin-client-crt,omitempty"`
+	// The admin client key to be used for Kubernetes services.
+	// If omitted defaults to an auto generated key.
 	AdminClientKey                  *string `json:"admin-client-key,omitempty" yaml:"admin-client-key,omitempty"`
+	// The client certificate to be used for the kube-proxy.
+	// If omitted defaults to an auto generated certificate.
 	KubeProxyClientCert             *string `json:"kube-proxy-client-crt,omitempty" yaml:"kube-proxy-client-crt,omitempty"`
+	// The client key to be used for the kube-proxy.
+	// If omitted defaults to an auto generated key.
 	KubeProxyClientKey              *string `json:"kube-proxy-client-key,omitempty" yaml:"kube-proxy-client-key,omitempty"`
+	// The client certificate to be used for the kube-scheduler.
+	// If omitted defaults to an auto generated certificate.
 	KubeSchedulerClientCert         *string `json:"kube-scheduler-client-crt,omitempty" yaml:"kube-scheduler-client-crt,omitempty"`
+	// The client key to be used for the kube-scheduler.
+	// If omitted defaults to an auto generated key.
 	KubeSchedulerClientKey          *string `json:"kube-scheduler-client-key,omitempty" yaml:"kube-scheduler-client-key,omitempty"`
+	// The client certificate to be used for the Kubernetes controller manager.
+	// If omitted defaults to an auto generated certificate.
 	KubeControllerManagerClientCert *string `json:"kube-controller-manager-client-crt,omitempty" yaml:"kube-controller-manager-client-crt,omitempty"`
+	// The client key to be used for the Kubernetes controller manager.
+	// If omitted defaults to an auto generated key.
 	KubeControllerManagerClientKey  *string `json:"kube-controller-manager-client-key,omitempty" yaml:"kube-ControllerManager-client-key,omitempty"`
 	// The key to be used by the default service account.
 	// If omitted defaults to an auto generated key.
@@ -103,7 +124,11 @@ type BootstrapConfig struct {
 	// The key to be used for the kubelet.
 	// If omitted defaults to an auto generated key.
 	KubeletKey        *string `json:"kubelet-key,omitempty" yaml:"kubelet-key,omitempty"`
+	// The certificate to be used for the kubelet client.
+	// If omitted defaults to an auto generated certificate.
 	KubeletClientCert *string `json:"kubelet-client-crt,omitempty" yaml:"kubelet-client-crt,omitempty"`
+	// The key to be used for the kubelet client.
+	// If omitted defaults to an auto generated key.
 	KubeletClientKey  *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
 
 	// Additional files that are uploaded `/var/snap/k8s/common/args/conf.d/<filename>`
@@ -115,33 +140,33 @@ type BootstrapConfig struct {
 
 	// Extra args to add to individual services (set any arg to null to delete).
 
-	// Additional arguments that are passed to the `kube-apiserver` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to the `kube-apiserver` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeAPIServerArgs         map[string]*string `json:"extra-node-kube-apiserver-args,omitempty" yaml:"extra-node-kube-apiserver-args,omitempty"`
-	// Additional arguments that are passed to the `kube-controller-manager` only for
-	// that specific node. Overwrites default configuration. A parameter that is
-	// explicitly set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to the `kube-controller-manager` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeControllerManagerArgs map[string]*string `json:"extra-node-kube-controller-manager-args,omitempty" yaml:"extra-node-kube-controller-manager-args,omitempty"`
-	// Additional arguments that are passed to the `kube-scheduler` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to the `kube-scheduler` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeSchedulerArgs         map[string]*string `json:"extra-node-kube-scheduler-args,omitempty" yaml:"extra-node-kube-scheduler-args,omitempty"`
-	// Additional arguments that are passed to the `kube-proxy` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to the `kube-proxy` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeProxyArgs             map[string]*string `json:"extra-node-kube-proxy-args,omitempty" yaml:"extra-node-kube-proxy-args,omitempty"`
-	// Additional arguments that are passed to the `kubelet` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to the `kubelet` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeletArgs               map[string]*string `json:"extra-node-kubelet-args,omitempty" yaml:"extra-node-kubelet-args,omitempty"`
-	// Additional arguments that are passed to `containerd` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to `containerd` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeContainerdArgs            map[string]*string `json:"extra-node-containerd-args,omitempty" yaml:"extra-node-containerd-args,omitempty"`
-	// Additional arguments that are passed to `k8s-dqlite` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to `k8s-dqlite` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeK8sDqliteArgs             map[string]*string `json:"extra-node-k8s-dqlite-args,omitempty" yaml:"extra-node-k8s-dqlite-args,omitempty"`
 
 	// Extra configuration for the containerd config.toml

--- a/api/v1/type_cluster_config.go
+++ b/api/v1/type_cluster_config.go
@@ -8,21 +8,46 @@ import (
 )
 
 type UserFacingClusterConfig struct {
+	// Configuration options for the network feature.
 	Network       NetworkConfig       `json:"network,omitempty" yaml:"network,omitempty"`
+	// Configuration options for the dns feature.
 	DNS           DNSConfig           `json:"dns,omitempty" yaml:"dns,omitempty"`
+	// Configuration options for the ingress feature.
 	Ingress       IngressConfig       `json:"ingress,omitempty" yaml:"ingress,omitempty"`
+	// Configuration options for the load-balancer feature.
 	LoadBalancer  LoadBalancerConfig  `json:"load-balancer,omitempty" yaml:"load-balancer,omitempty"`
+	// Configuration options for the local-storage feature.
 	LocalStorage  LocalStorageConfig  `json:"local-storage,omitempty" yaml:"local-storage,omitempty"`
+	// Configuration options for the gateway feature.
 	Gateway       GatewayConfig       `json:"gateway,omitempty" yaml:"gateway,omitempty"`
+	// Configuration options for the metric server feature.
 	MetricsServer MetricsServerConfig `json:"metrics-server,omitempty" yaml:"metrics-server,omitempty"`
+	// Sets the cloud provider to be used by the cluster.
+	//
+	// When this is set as `external`, node will wait for an external cloud provider to
+	// do cloud specific setup and finish node initialization.
+	//
+	// Possible values: `external`.
 	CloudProvider *string             `json:"cloud-provider,omitempty" yaml:"cloud-provider,omitempty"`
 	Annotations   map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
 type DNSConfig struct {
+	// Determines if the feature should be enabled.
+	// If omitted defaults to `true`
 	Enabled             *bool     `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	// Sets the local domain of the cluster.
+	// If omitted defaults to `cluster.local`.
 	ClusterDomain       *string   `json:"cluster-domain,omitempty" yaml:"cluster-domain,omitempty"`
+	// Sets the IP address of the dns service. If omitted defaults to the IP address
+	// of the Kubernetes service created by the feature.
+	//
+	// Can be used to point to an external dns server when feature is disabled.
 	ServiceIP           *string   `json:"service-ip,omitempty" yaml:"service-ip,omitempty"`
+	// Sets the upstream nameservers used to forward queries for out-of-cluster
+	// endpoints.
+	//
+	// If omitted defaults to `/etc/resolv.conf` and uses the nameservers of the node.
 	UpstreamNameservers *[]string `json:"upstream-nameservers,omitempty" yaml:"upstream-nameservers,omitempty"`
 }
 
@@ -32,8 +57,17 @@ func (c DNSConfig) GetServiceIP() string             { return util.Deref(c.Servi
 func (c DNSConfig) GetUpstreamNameservers() []string { return util.Deref(c.UpstreamNameservers) }
 
 type IngressConfig struct {
+	// Determines if the feature should be enabled.
+	// If omitted defaults to `false`
 	Enabled             *bool   `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	// Sets the name of the secret to be used for providing default encryption to
+	// ingresses.
+	//
+	// Ingresses can specify another TLS secret in their resource definitions,
+	// in which case the default secret won't be used.
 	DefaultTLSSecret    *string `json:"default-tls-secret,omitempty" yaml:"default-tls-secret,omitempty"`
+	// Determines if the proxy protocol should be enabled for ingresses.
+	// If omitted defaults to `false`.
 	EnableProxyProtocol *bool   `json:"enable-proxy-protocol,omitempty" yaml:"enable-proxy-protocol,omitempty"`
 }
 
@@ -42,14 +76,32 @@ func (c IngressConfig) GetDefaultTLSSecret() string  { return util.Deref(c.Defau
 func (c IngressConfig) GetEnableProxyProtocol() bool { return util.Deref(c.EnableProxyProtocol) }
 
 type LoadBalancerConfig struct {
+	// Determines if the feature should be enabled.
+	// If omitted defaults to `false`.
 	Enabled        *bool     `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	// Sets the CIDRs used for assigning IP addresses to Kubernetes services with type
+	// `LoadBalancer`.
 	CIDRs          *[]string `json:"cidrs,omitempty" yaml:"cidrs,omitempty"`
+	// Determines if L2 mode should be enabled.
+	// If omitted defaults to `false`.
 	L2Mode         *bool     `json:"l2-mode,omitempty" yaml:"l2-mode,omitempty"`
+	// Sets the interfaces to be used for announcing IP addresses through ARP.
+	// If omitted all interfaces will be used.
 	L2Interfaces   *[]string `json:"l2-interfaces,omitempty" yaml:"l2-interfaces,omitempty"`
+	// Determines if BGP mode should be enabled.
+	// If omitted defaults to `false`.
 	BGPMode        *bool     `json:"bgp-mode,omitempty" yaml:"bgp-mode,omitempty"`
+	// Sets the ASN to be used for the local virtual BGP router.
+	// Required if bgp-mode is true.
 	BGPLocalASN    *int      `json:"bgp-local-asn,omitempty" yaml:"bgp-local-asn,omitempty"`
+	// Sets the IP address of the BGP peer.
+	// Required if bgp-mode is true.
 	BGPPeerAddress *string   `json:"bgp-peer-address,omitempty" yaml:"bgp-peer-address,omitempty"`
+	// Sets the ASN of the BGP peer.
+	// Required if bgp-mode is true.
 	BGPPeerASN     *int      `json:"bgp-peer-asn,omitempty" yaml:"bgp-peer-asn,omitempty"`
+	// Sets the port of the BGP peer.
+	// Required if bgp-mode is true.
 	BGPPeerPort    *int      `json:"bgp-peer-port,omitempty" yaml:"bgp-peer-port,omitempty"`
 }
 
@@ -64,9 +116,18 @@ func (c LoadBalancerConfig) GetBGPPeerASN() int        { return util.Deref(c.BGP
 func (c LoadBalancerConfig) GetBGPPeerPort() int       { return util.Deref(c.BGPPeerPort) }
 
 type LocalStorageConfig struct {
+	// Determines if the feature should be enabled.
+	// If omitted defaults to `false`.
 	Enabled       *bool   `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	// Sets the path to be used for storing volume data.
+	// If omitted defaults to `/var/snap/k8s/common/rawfile-storage`
 	LocalPath     *string `json:"local-path,omitempty" yaml:"local-path,omitempty"`
+	// Sets the reclaim policy of the storage class.
+	// If omitted defaults to `Delete`.
+	// Possible values: `Retain | Recycle | Delete`
 	ReclaimPolicy *string `json:"reclaim-policy,omitempty" yaml:"reclaim-policy,omitempty"`
+	// Determines if the storage class should be set as default.
+	// If omitted defaults to `true`
 	Default       *bool   `json:"default,omitempty" yaml:"default,omitempty"`
 }
 
@@ -76,12 +137,16 @@ func (c LocalStorageConfig) GetReclaimPolicy() string { return util.Deref(c.Recl
 func (c LocalStorageConfig) GetDefault() bool         { return util.Deref(c.Default) }
 
 type NetworkConfig struct {
+	// Determines if the feature should be enabled.
+	// If omitted defaults to `true`
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 }
 
 func (c NetworkConfig) GetEnabled() bool { return util.Deref(c.Enabled) }
 
 type GatewayConfig struct {
+	// Determines if the feature should be enabled.
+	// If omitted defaults to `true`.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 }
 

--- a/api/v1/type_cluster_config.go
+++ b/api/v1/type_cluster_config.go
@@ -29,6 +29,8 @@ type UserFacingClusterConfig struct {
 	//
 	// Possible values: `external`.
 	CloudProvider *string             `json:"cloud-provider,omitempty" yaml:"cloud-provider,omitempty"`
+	// Annotations is a map of strings that can be used to store arbitrary metadata configuration.
+	// Please refer to the ClusterAPI annotations reference for further details on these options.
 	Annotations   map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 

--- a/api/v1/type_cluster_config.go
+++ b/api/v1/type_cluster_config.go
@@ -155,6 +155,8 @@ type GatewayConfig struct {
 func (c GatewayConfig) GetEnabled() bool { return util.Deref(c.Enabled) }
 
 type MetricsServerConfig struct {
+	// Determines if the feature should be enabled.
+	// If omitted defaults to `true`.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 }
 
@@ -163,9 +165,13 @@ func (c MetricsServerConfig) GetEnabled() bool { return util.Deref(c.Enabled) }
 type UserFacingDatastoreConfig struct {
 	// Type of the datastore. Needs to be "external".
 	Type       *string   `json:"type,omitempty" yaml:"type,omitempty"`
+	// Datastore server addresses.
 	Servers    *[]string `json:"servers,omitempty" yaml:"servers,omitempty"`
+	// Datastore CA certificate.
 	CACert     *string   `json:"ca-crt,omitempty" yaml:"ca-crt,omitempty"`
+	// Datastore client certificate.
 	ClientCert *string   `json:"client-crt,omitempty" yaml:"client-crt,omitempty"`
+	// Datastore client key.
 	ClientKey  *string   `json:"client-key,omitempty" yaml:"client-key,omitempty"`
 }
 

--- a/api/v1/type_control_plane_join_config.go
+++ b/api/v1/type_control_plane_join_config.go
@@ -5,35 +5,79 @@ import (
 )
 
 type ControlPlaneJoinConfig struct {
+	// List of extra SANs to be added to certificates.
 	ExtraSANS []string `json:"extra-sans,omitempty" yaml:"extra-sans,omitempty"`
 
 	// Seed certificates for external CA
+
+	// The client certificate to be used for the front proxy.
+	// If omitted defaults to an auto generated certificate.
 	FrontProxyClientCert            *string `json:"front-proxy-client-crt,omitempty" yaml:"front-proxy-client-crt,omitempty"`
+	// The client key to be used for the front proxy.
+	// If omitted defaults to an auto generated key.
 	FrontProxyClientKey             *string `json:"front-proxy-client-key,omitempty" yaml:"front-proxy-client-key,omitempty"`
+	// The client certificate to be used by kubelet for communicating with the kube-apiserver.
+	// If omitted defaults to an auto generated certificate.
 	KubeProxyClientCert             *string `json:"kube-proxy-client-crt,omitempty" yaml:"kube-proxy-client-crt,omitempty"`
+	// The client key to be used by kubelet for communicating with the kube-apiserver.
+	// If omitted defaults to an auto generated key.
 	KubeProxyClientKey              *string `json:"kube-proxy-client-key,omitempty" yaml:"kube-proxy-client-key,omitempty"`
 	KubeSchedulerClientCert         *string `json:"kube-scheduler-client-crt,omitempty" yaml:"kube-scheduler-client-crt,omitempty"`
 	KubeSchedulerClientKey          *string `json:"kube-scheduler-client-key,omitempty" yaml:"kube-scheduler-client-key,omitempty"`
 	KubeControllerManagerClientCert *string `json:"kube-controller-manager-client-crt,omitempty" yaml:"kube-controller-manager-client-crt,omitempty"`
 	KubeControllerManagerClientKey  *string `json:"kube-controller-manager-client-key,omitempty" yaml:"kube-ControllerManager-client-key,omitempty"`
 
+	// The certificate to be used for the kube-apiserver.
+	// If omitted defaults to an auto generated certificate.
 	APIServerCert     *string `json:"apiserver-crt,omitempty" yaml:"apiserver-crt,omitempty"`
+	// The key to be used for the kube-apiserver.
+	// If omitted defaults to an auto generated key.
 	APIServerKey      *string `json:"apiserver-key,omitempty" yaml:"apiserver-key,omitempty"`
+	// The certificate to be used for the kubelet.
+	// If omitted defaults to an auto generated certificate.
 	KubeletCert       *string `json:"kubelet-crt,omitempty" yaml:"kubelet-crt,omitempty"`
+	// The key to be used for the kubelet.
+	// If omitted defaults to an auto generated key.
 	KubeletKey        *string `json:"kubelet-key,omitempty" yaml:"kubelet-key,omitempty"`
 	KubeletClientCert *string `json:"kubelet-client-crt,omitempty" yaml:"kubelet-client-crt,omitempty"`
 	KubeletClientKey  *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
 
-	// ExtraNodeConfigFiles will be written to /var/snap/k8s/common/args/conf.d
+	// Additional files that are uploaded `/var/snap/k8s/common/args/conf.d/<filename>`
+	// to a node on bootstrap. These files can then be referenced by Kubernetes
+	// service arguments.
+	//
+	// The format is `map[<filename>]<filecontent>`.
 	ExtraNodeConfigFiles map[string]string `json:"extra-node-config-files,omitempty" yaml:"extra-node-config-files,omitempty"`
 
-	// Extra args to add to individual services (set any arg to null to delete)
+	// Extra args to add to individual services (set any arg to null to delete).
+
+	// Additional arguments that are passed to the `kube-apiserver` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeAPIServerArgs         map[string]*string `json:"extra-node-kube-apiserver-args,omitempty" yaml:"extra-node-kube-apiserver-args,omitempty"`
+	// Additional arguments that are passed to the `kube-controller-manager` only for
+	// that specific node. Overwrites default configuration. A parameter that is
+	// explicitly set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeControllerManagerArgs map[string]*string `json:"extra-node-kube-controller-manager-args,omitempty" yaml:"extra-node-kube-controller-manager-args,omitempty"`
+	// Additional arguments that are passed to the `kube-scheduler` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeSchedulerArgs         map[string]*string `json:"extra-node-kube-scheduler-args,omitempty" yaml:"extra-node-kube-scheduler-args,omitempty"`
+	// Additional arguments that are passed to the `kube-proxy` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeProxyArgs             map[string]*string `json:"extra-node-kube-proxy-args,omitempty" yaml:"extra-node-kube-proxy-args,omitempty"`
+	// Additional arguments that are passed to the `kubelet` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeletArgs               map[string]*string `json:"extra-node-kubelet-args,omitempty" yaml:"extra-node-kubelet-args,omitempty"`
+	// Additional arguments that are passed to `containerd` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeContainerdArgs            map[string]*string `json:"extra-node-containerd-args,omitempty" yaml:"extra-node-containerd-args,omitempty"`
+	// Additional arguments that are passed to `k8s-dqlite` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeK8sDqliteArgs             map[string]*string `json:"extra-node-k8s-dqlite-args,omitempty" yaml:"extra-node-k8s-dqlite-args,omitempty"`
 
 	// Extra configuration for the containerd config.toml

--- a/api/v1/type_control_plane_join_config.go
+++ b/api/v1/type_control_plane_join_config.go
@@ -22,9 +22,17 @@ type ControlPlaneJoinConfig struct {
 	// The client key to be used by kubelet for communicating with the kube-apiserver.
 	// If omitted defaults to an auto generated key.
 	KubeProxyClientKey              *string `json:"kube-proxy-client-key,omitempty" yaml:"kube-proxy-client-key,omitempty"`
+	// The client certificate to be used for the kube-scheduler.
+	// If omitted defaults to an auto generated certificate.
 	KubeSchedulerClientCert         *string `json:"kube-scheduler-client-crt,omitempty" yaml:"kube-scheduler-client-crt,omitempty"`
+	// The client key to be used for the kube-scheduler.
+	// If omitted defaults to an auto generated key.
 	KubeSchedulerClientKey          *string `json:"kube-scheduler-client-key,omitempty" yaml:"kube-scheduler-client-key,omitempty"`
+	// The client certificate to be used for the Kubernetes controller manager.
+	// If omitted defaults to an auto generated certificate.
 	KubeControllerManagerClientCert *string `json:"kube-controller-manager-client-crt,omitempty" yaml:"kube-controller-manager-client-crt,omitempty"`
+	// The client key to be used for the Kubernetes controller manager.
+	// If omitted defaults to an auto generated key.
 	KubeControllerManagerClientKey  *string `json:"kube-controller-manager-client-key,omitempty" yaml:"kube-ControllerManager-client-key,omitempty"`
 
 	// The certificate to be used for the kube-apiserver.
@@ -39,7 +47,11 @@ type ControlPlaneJoinConfig struct {
 	// The key to be used for the kubelet.
 	// If omitted defaults to an auto generated key.
 	KubeletKey        *string `json:"kubelet-key,omitempty" yaml:"kubelet-key,omitempty"`
+	// The client certificate to be used for the kubelet.
+	// If omitted defaults to an auto generated certificate.
 	KubeletClientCert *string `json:"kubelet-client-crt,omitempty" yaml:"kubelet-client-crt,omitempty"`
+	// The client key to be used for the kubelet.
+	// If omitted defaults to an auto generated key.
 	KubeletClientKey  *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
 
 	// Additional files that are uploaded `/var/snap/k8s/common/args/conf.d/<filename>`

--- a/api/v1/type_control_plane_join_config.go
+++ b/api/v1/type_control_plane_join_config.go
@@ -51,33 +51,33 @@ type ControlPlaneJoinConfig struct {
 
 	// Extra args to add to individual services (set any arg to null to delete).
 
-	// Additional arguments that are passed to the `kube-apiserver` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to the `kube-apiserver` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeAPIServerArgs         map[string]*string `json:"extra-node-kube-apiserver-args,omitempty" yaml:"extra-node-kube-apiserver-args,omitempty"`
-	// Additional arguments that are passed to the `kube-controller-manager` only for
-	// that specific node. Overwrites default configuration. A parameter that is
-	// explicitly set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to the `kube-controller-manager` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeControllerManagerArgs map[string]*string `json:"extra-node-kube-controller-manager-args,omitempty" yaml:"extra-node-kube-controller-manager-args,omitempty"`
-	// Additional arguments that are passed to the `kube-scheduler` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to the `kube-scheduler` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeSchedulerArgs         map[string]*string `json:"extra-node-kube-scheduler-args,omitempty" yaml:"extra-node-kube-scheduler-args,omitempty"`
-	// Additional arguments that are passed to the `kube-proxy` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to the `kube-proxy` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeProxyArgs             map[string]*string `json:"extra-node-kube-proxy-args,omitempty" yaml:"extra-node-kube-proxy-args,omitempty"`
-	// Additional arguments that are passed to the `kubelet` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to the `kubelet` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeletArgs               map[string]*string `json:"extra-node-kubelet-args,omitempty" yaml:"extra-node-kubelet-args,omitempty"`
-	// Additional arguments that are passed to `containerd` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to `containerd` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeContainerdArgs            map[string]*string `json:"extra-node-containerd-args,omitempty" yaml:"extra-node-containerd-args,omitempty"`
-	// Additional arguments that are passed to `k8s-dqlite` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to `k8s-dqlite` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeK8sDqliteArgs             map[string]*string `json:"extra-node-k8s-dqlite-args,omitempty" yaml:"extra-node-k8s-dqlite-args,omitempty"`
 
 	// Extra configuration for the containerd config.toml

--- a/api/v1/type_worker_node_join_config.go
+++ b/api/v1/type_worker_node_join_config.go
@@ -23,21 +23,21 @@ type WorkerJoinConfig struct {
 
 	// Extra args to add to individual services (set any arg to null to delete)
 
-	// Additional arguments that are passed to the `kube-proxy` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to the `kube-proxy` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeProxyArgs         map[string]*string `json:"extra-node-kube-proxy-args,omitempty" yaml:"extra-node-kube-proxy-args,omitempty"`
-	// Additional arguments that are passed to the `kubelet` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to the `kubelet` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeletArgs           map[string]*string `json:"extra-node-kubelet-args,omitempty" yaml:"extra-node-kubelet-args,omitempty"`
-	// Additional arguments that are passed to `containerd` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to `containerd` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeContainerdArgs        map[string]*string `json:"extra-node-containerd-args,omitempty" yaml:"extra-node-containerd-args,omitempty"`
-	// Additional arguments that are passed to `k8s-api-server-proxy` only for that
-	// specific node. Overwrites default configuration. A parameter that is explicitly
-	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
+	// Additional arguments that are passed to `k8s-api-server-proxy` only for that specific node.
+	// A parameter that is explicitly set to `null` is deleted.
+	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeK8sAPIServerProxyArgs map[string]*string `json:"extra-node-k8s-apiserver-proxy-args,omitempty" yaml:"extra-node-k8s-apiserver-proxy-args,omitempty"`
 
 	// Extra configuration for the containerd config.toml

--- a/api/v1/type_worker_node_join_config.go
+++ b/api/v1/type_worker_node_join_config.go
@@ -3,20 +3,41 @@ package apiv1
 import "github.com/canonical/k8s-snap-api/internal/util"
 
 type WorkerJoinConfig struct {
+	// The certificate to be used for the kubelet.
+	// If omitted defaults to an auto generated certificate.
 	KubeletCert         *string `json:"kubelet-crt,omitempty" yaml:"kubelet-crt,omitempty"`
+	// The key to be used for the kubelet.
+	// If omitted defaults to an auto generated key.
 	KubeletKey          *string `json:"kubelet-key,omitempty" yaml:"kubelet-key,omitempty"`
 	KubeletClientCert   *string `json:"kubelet-client-crt,omitempty" yaml:"kubelet-client-crt,omitempty"`
 	KubeletClientKey    *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
 	KubeProxyClientCert *string `json:"kube-proxy-client-crt,omitempty" yaml:"kube-proxy-client-crt,omitempty"`
 	KubeProxyClientKey  *string `json:"kube-proxy-client-key,omitempty" yaml:"kube-proxy-client-key,omitempty"`
 
-	// ExtraNodeConfigFiles will be written to /var/snap/k8s/common/args/conf.d
+	// Additional files that are uploaded `/var/snap/k8s/common/args/conf.d/<filename>`
+	// to a node on bootstrap. These files can then be referenced by Kubernetes
+	// service arguments.
+	//
+	// The format is `map[<filename>]<filecontent>`.
 	ExtraNodeConfigFiles map[string]string `json:"extra-node-config-files,omitempty" yaml:"extra-node-config-files,omitempty"`
 
 	// Extra args to add to individual services (set any arg to null to delete)
+
+	// Additional arguments that are passed to the `kube-proxy` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeProxyArgs         map[string]*string `json:"extra-node-kube-proxy-args,omitempty" yaml:"extra-node-kube-proxy-args,omitempty"`
+	// Additional arguments that are passed to the `kubelet` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeKubeletArgs           map[string]*string `json:"extra-node-kubelet-args,omitempty" yaml:"extra-node-kubelet-args,omitempty"`
+	// Additional arguments that are passed to `containerd` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeContainerdArgs        map[string]*string `json:"extra-node-containerd-args,omitempty" yaml:"extra-node-containerd-args,omitempty"`
+	// Additional arguments that are passed to `k8s-api-server-proxy` only for that
+	// specific node. Overwrites default configuration. A parameter that is explicitly
+	// set to `null` is deleted. The format is `map[<--flag-name>]<value>`.
 	ExtraNodeK8sAPIServerProxyArgs map[string]*string `json:"extra-node-k8s-apiserver-proxy-args,omitempty" yaml:"extra-node-k8s-apiserver-proxy-args,omitempty"`
 
 	// Extra configuration for the containerd config.toml

--- a/api/v1/type_worker_node_join_config.go
+++ b/api/v1/type_worker_node_join_config.go
@@ -9,9 +9,17 @@ type WorkerJoinConfig struct {
 	// The key to be used for the kubelet.
 	// If omitted defaults to an auto generated key.
 	KubeletKey          *string `json:"kubelet-key,omitempty" yaml:"kubelet-key,omitempty"`
+	// The client certificate to be used for the kubelet.
+	// If omitted defaults to an auto generated certificate.
 	KubeletClientCert   *string `json:"kubelet-client-crt,omitempty" yaml:"kubelet-client-crt,omitempty"`
+	// The client key to be used for the kubelet.
+	// If omitted defaults to an auto generated key.
 	KubeletClientKey    *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
+	// The client certificate to be used for the kube-proxy.
+	// If omitted defaults to an auto generated certificate.
 	KubeProxyClientCert *string `json:"kube-proxy-client-crt,omitempty" yaml:"kube-proxy-client-crt,omitempty"`
+	// The client key to be used for the kube-proxy.
+	// If omitted defaults to an auto generated key.
 	KubeProxyClientKey  *string `json:"kube-proxy-client-key,omitempty" yaml:"kube-proxy-client-key,omitempty"`
 
 	// Additional files that are uploaded `/var/snap/k8s/common/args/conf.d/<filename>`


### PR DESCRIPTION
The bootstrap and node join config documentation can easily get out of sync, for which reason we intend to automatically generate the documentation based on structure docstrings.

To do so, we're copying over the field descriptions from the following document:

* https://github.com/canonical/k8s-snap/blob/ee017318d958b4c7ed1ab78d3cf4d8b7e94559c5/docs/src/snap/reference/bootstrap-config-reference.md

A separate PR adds the necessary automation. Check docs/src/_parts/bootstrap_config.md for a sample of the generated Markdown document.

* https://github.com/canonical/k8s-snap/pull/711

Note that in order to be picked up, the inline comments must be placed immediately before the corresponding structure field.

Certain comments may only be intended for developers, just add a new line to avoid including these comments in the generated documentation:

```
    type SomeStruct struct {
        // skipped comment

        SomeField int `json:"some-field"`

        // multiline comment
        //
        // of a given field
        OtherField string `json:"other-field"`
    }
```