### PR TITLE
Add GetCloudProvider()

### DIFF
--- a/api/v1/type_cluster_config.go
+++ b/api/v1/type_cluster_config.go
@@ -34,6 +34,8 @@ type UserFacingClusterConfig struct {
 	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
+func (c UserFacingClusterConfig) GetCloudProvider() string { return util.Deref(c.CloudProvider) }
+
 type DNSConfig struct {
 	// Determines if the feature should be enabled.
 	// If omitted defaults to `true`


### PR DESCRIPTION
Adds GetCloudProvider() which dereferences the cloud-provider pointer in a safe way. This change is needed to implement `k8s get cloud-provider` in k8s-snap.