### PR TITLE
Adds containerd-base-dir field to BootstrapConfig and *JoinConfig

### DIFF
--- a/api/v1/type_bootstrap_config.go
+++ b/api/v1/type_bootstrap_config.go
@@ -171,6 +171,9 @@ type BootstrapConfig struct {
 
 	// Extra configuration for the containerd config.toml
 	ExtraNodeContainerdConfig MapStringAny `json:"extra-node-containerd-config,omitempty" yaml:"extra-node-containerd-config,omitempty"`
+
+	// The base directory in which the containerd-related files are located.
+	ContainerdBaseDir string `json:"containerd-base-dir,omitempty" yaml:"containerd-base-dir,omitempty"`
 }
 
 func (b *BootstrapConfig) GetDatastoreType() string        { return util.Deref(b.DatastoreType) }

--- a/api/v1/type_control_plane_join_config.go
+++ b/api/v1/type_control_plane_join_config.go
@@ -94,6 +94,9 @@ type ControlPlaneJoinConfig struct {
 
 	// Extra configuration for the containerd config.toml
 	ExtraNodeContainerdConfig MapStringAny `json:"extra-node-containerd-config,omitempty" yaml:"extra-node-containerd-config,omitempty"`
+
+	// The base directory in which the containerd-related files are located.
+	ContainerdBaseDir string `json:"containerd-base-dir,omitempty" yaml:"containerd-base-dir,omitempty"`
 }
 
 func (c *ControlPlaneJoinConfig) GetFrontProxyClientCert() string {

--- a/api/v1/type_worker_node_join_config.go
+++ b/api/v1/type_worker_node_join_config.go
@@ -50,6 +50,9 @@ type WorkerJoinConfig struct {
 
 	// Extra configuration for the containerd config.toml
 	ExtraNodeContainerdConfig MapStringAny `json:"extra-node-containerd-config,omitempty" yaml:"extra-node-containerd-config,omitempty"`
+
+	// The base directory in which the containerd-related files are located.
+	ContainerdBaseDir string `json:"containerd-base-dir,omitempty" yaml:"containerd-base-dir,omitempty"`
 }
 
 func (w *WorkerJoinConfig) GetKubeletCert() string       { return util.Deref(w.KubeletCert) }


### PR DESCRIPTION
…erRequest

Currently, for the classic k8s snap, the default locations for the containerd-related files are:

```
- /etc/containerd/
- /run/containerd/
- /var/lib/containerd/
```

These paths can conflict with other containerd installations on the host (e.g. from docker), meaning that the k8s snap cannot be installed. In a developer's usecase, we shouldn't require the other services to be disabled, but we can allow the k8s snap's containerd to be installed in a different location during bootstrap / node join.

Needed-By: https://github.com/canonical/k8s-snap/pull/817