### PR TITLE
Add review kubernetes auth token RPC

### DIFF
--- a/api/v1/rpc_review_kubernetes_auth_token.go
+++ b/api/v1/rpc_review_kubernetes_auth_token.go
@@ -1,0 +1,4 @@
+package apiv1
+
+// ReviewKubernetesAuthTokenRPC is the path for the ReviewKubernetesAuthToken RPC.
+const ReviewKubernetesAuthTokenRPC string = "kubernetes/auth/webhook"


### PR DESCRIPTION
### Overview
This PR adds the ReviewKubernetesAuthTokenRPC to be replaced in [k8s-snap](https://github.com/canonical/k8s-snap/blob/main/src/k8s/pkg/k8sd/api/endpoints.go#L124).