### PR TITLE
Enable cluster-config.load-balancer.l2-mode by default

### DIFF
--- a/api/v1/type_cluster_config.go
+++ b/api/v1/type_cluster_config.go
@@ -85,7 +85,7 @@ type LoadBalancerConfig struct {
 	// `LoadBalancer`.
 	CIDRs *[]string `json:"cidrs,omitempty" yaml:"cidrs,omitempty"`
 	// Determines if L2 mode should be enabled.
-	// If omitted defaults to `false`.
+	// If omitted defaults to `true`.
 	L2Mode *bool `json:"l2-mode,omitempty" yaml:"l2-mode,omitempty"`
 	// Sets the interfaces to be used for announcing IP addresses through ARP.
 	// If omitted all interfaces will be used.


### PR DESCRIPTION
We'll change the defalt value of cluster-config.load-balancer.l2-mode, enabling it by default.

This commit updates the docstring while a k8s-snap PR applies the default value.

k8s-snap PR: https://github.com/canonical/k8s-snap/pull/1001