### PR TITLE
Add annotation: k8sd/v1alpha1/cilium/sctp/enabled

### DIFF
--- a/api/v1/annotations/cilium/annotations.go
+++ b/api/v1/annotations/cilium/annotations.go
@@ -28,4 +28,7 @@ const (
 	// bypassing all VLANs.
 	// e.g., k8sd/v1alpha1/cilium/vlan-bpf-bypass="4001,4002"
 	AnnotationVLANBPFBypass = "k8sd/v1alpha1/cilium/vlan-bpf-bypass"
+
+	// Enable the Cilium SCTP feature.
+	AnnotationSCTPEnabled = "k8sd/v1alpha1/cilium/sctp/enabled"
 )


### PR DESCRIPTION
We need an annotation to optionally enable the Cilium SCTP feature.