### PR TITLE
feat: Add endpoint for feature reconcilation

### DIFF
--- a/api/v1/rpc_feature_reconcile.go
+++ b/api/v1/rpc_feature_reconcile.go
@@ -1,0 +1,18 @@
+package apiv1
+
+// ReconcileFeaturesRPC is the path for the ReconcileFeatures RPC.
+const ReconcileFeaturesRPC = "k8sd/cluster/features/reconcile"
+
+// ReconcileFeaturesRequest is the request message for the ReconcileFeatures RPC.
+type ReconcileFeaturesRequest struct {
+	Network       bool `json:"network"`
+	Ingress       bool `json:"ingress"`
+	LoadBalancer  bool `json:"load-balancer"`
+	LocalStorage  bool `json:"local-storage"`
+	Gateway       bool `json:"gateway"`
+	MetricsServer bool `json:"metrics-server"`
+	DNS           bool `json:"dns"`
+}
+
+// ReconcileFeaturesResponse is the response message for the ReconcileFeatures RPC.
+type ReconcileFeaturesResponse struct{}


### PR DESCRIPTION
The request body is a dictionary of `feature: bool` that determines which features to reconcile.
The reconcilation should be performed only on the leader node, calling this endpoint on a non-leader node should result in an error response.