### PR TITLE
Annotations: add cilium tunnel-port option

### DIFF
--- a/api/v1/annotations/cilium/annotations.go
+++ b/api/v1/annotations/cilium/annotations.go
@@ -31,4 +31,12 @@ const (
 
 	// Enable the Cilium SCTP feature.
 	AnnotationSCTPEnabled = "k8sd/v1alpha1/cilium/sctp/enabled"
+
+	// Set the VXLAN tunnel port. if not provided, default value is port 8472.
+	// In cases where you have specific firewall requirements or you have
+	// fan networking enabled on your underlay network with the same vxlan
+	// destination port, setting this option to a different port could mitigate
+	// the issues.
+	// e.g., k8sd/v1alpha1/cilium/tunnel-port="8473"
+	AnnotationTunnelPort = "k8sd/v1alpha1/cilium/tunnel-port"
 )

--- a/api/v1/annotations/cilium/annotations.go
+++ b/api/v1/annotations/cilium/annotations.go
@@ -32,11 +32,13 @@ const (
 	// Enable the Cilium SCTP feature.
 	AnnotationSCTPEnabled = "k8sd/v1alpha1/cilium/sctp/enabled"
 
-	// Set the VXLAN tunnel port. if not provided, default value is port 8472.
+	// Set the VXLAN tunnel port. if not provided, Cilium default values
+	// will be used. The default values are defined here:
+	// https://docs.cilium.io/en/stable/operations/system_requirements/
 	// In cases where you have specific firewall requirements or you have
 	// fan networking enabled on your underlay network with the same vxlan
 	// destination port, setting this option to a different port could mitigate
 	// the issues.
-	// e.g., k8sd/v1alpha1/cilium/tunnel-port="8473"
+	// e.g., k8sd/v1alpha1/cilium/tunnel-port="8472"
 	AnnotationTunnelPort = "k8sd/v1alpha1/cilium/tunnel-port"
 )


### PR DESCRIPTION
This PR suggests adding `tunnel-port` option to the list of Cilium annotations to provide user with a way to set another VXLAN port. This is particularly useful when Cilium's VXLAN conflicts with underlay network's fan networking feature. 