### PR TITLE
feat: add `certificates` to `refresh-certs` RPC

### DIFF
--- a/api/v1/rpc_refresh_certificates_plan.go
+++ b/api/v1/rpc_refresh_certificates_plan.go
@@ -4,7 +4,10 @@ package apiv1
 const RefreshCertificatesPlanRPC = "k8sd/refresh-certs/plan"
 
 // RefreshCertificatesPlanRequest is the request message for the RefreshCertificatesPlan RPC.
-type RefreshCertificatesPlanRequest struct{}
+type RefreshCertificatesPlanRequest struct {
+	// Certificates is an optional list of certificate names to refresh.
+	Certificates []string `json:"certificates"`
+}
 
 // RefreshCertificatesPlanResponse is the response message for the RefreshCertificatesPlan RPC.
 type RefreshCertificatesPlanResponse struct {

--- a/api/v1/rpc_refresh_certificates_run.go
+++ b/api/v1/rpc_refresh_certificates_run.go
@@ -5,6 +5,8 @@ const RefreshCertificatesRunRPC = "k8sd/refresh-certs/run"
 
 // RefreshCertificatesRunRequest is the request message for the RefreshCertificatesRun RPC.
 type RefreshCertificatesRunRequest struct {
+	// Certificates is an optional list of certificate names to refresh.
+	Certificates []string `json:"certificates"`
 	// Seed must match the value returned by the RefreshCertificatesPlan RPC.
 	Seed int `json:"seed"`
 	// ExpirationSeconds is the desired duration of the new certificates.


### PR DESCRIPTION
## Overview
Add support for sharing a Certificate names list for the `refresh-certs` RPC