### PR TITLE
feat: add system tuning on/off switch

### DIFF
--- a/api/v1/type_bootstrap_config.go
+++ b/api/v1/type_bootstrap_config.go
@@ -21,6 +21,9 @@ type BootstrapConfig struct {
 	// Determines if RBAC should be disabled.
 	// If omitted defaults to `false`.
 	DisableRBAC *bool `json:"disable-rbac,omitempty" yaml:"disable-rbac,omitempty"`
+	// Determines whether system tuning is allowed.
+	// If omitted defaults to `true`.
+	EnableSystemTuning *bool `json:"enable-system-tuning,omitempty" yaml:"enable-system-tuning,omitempty"`
 	// The port number for kube-apiserver to use.
 	// If omitted defaults to `6443`.
 	SecurePort *int `json:"secure-port,omitempty" yaml:"secure-port,omitempty"`

--- a/api/v1/type_control_plane_join_config.go
+++ b/api/v1/type_control_plane_join_config.go
@@ -60,6 +60,9 @@ type ControlPlaneJoinConfig struct {
 	// If omitted defaults to an auto generated key.
 	KubeletClientKey *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
 
+	// Determines whether system tuning is allowed.
+	// If omitted defaults to `true`.
+	EnableSystemTuning *bool `json:"enable-system-tuning,omitempty" yaml:"enable-system-tuning,omitempty"`
 	// Additional files that are uploaded `/var/snap/k8s/common/args/conf.d/<filename>`
 	// to a node on bootstrap. These files can then be referenced by Kubernetes
 	// service arguments.

--- a/api/v1/type_worker_node_join_config.go
+++ b/api/v1/type_worker_node_join_config.go
@@ -22,6 +22,9 @@ type WorkerJoinConfig struct {
 	// If omitted defaults to an auto generated key.
 	KubeProxyClientKey *string `json:"kube-proxy-client-key,omitempty" yaml:"kube-proxy-client-key,omitempty"`
 
+	// Determines whether system tuning is allowed.
+	// If omitted defaults to `true`.
+	EnableSystemTuning *bool `json:"enable-system-tuning,omitempty" yaml:"enable-system-tuning,omitempty"`
 	// Additional files that are uploaded `/var/snap/k8s/common/args/conf.d/<filename>`
 	// to a node on bootstrap. These files can then be referenced by Kubernetes
 	// service arguments.


### PR DESCRIPTION
## Description
We would like to add a configuration option to enable/disable system tuning on all nodes joining a cluster (bootstrap, control plane and worker nodes). 
