### PR TITLE
feat: enhance RemoveNodeResponse to include error details

### DIFF
--- a/api/v1/rpc_remove_node.go
+++ b/api/v1/rpc_remove_node.go
@@ -13,4 +13,16 @@ type RemoveNodeRequest struct {
 }
 
 // RemoveNodeResponse is the response message for the RemoveNode RPC.
-type RemoveNodeResponse struct{}
+type RemoveNodeResponse struct {
+	// Errors holds error messages from the various subsystems involved
+	// (if any). This is useful when Force is true and some subsystems
+	// fail to remove the node.
+	Errors *RemoveNodeErrors `json:"errors,omitempty"`
+}
+
+// RemoveNodeErrors holds error messages from the various subsystems involved
+type RemoveNodeErrors struct {
+	Kubernetes   string `json:"kubernetes,omitempty"`
+	Datastore    string `json:"datastore,omitempty"`
+	Microcluster string `json:"microcluster,omitempty"`
+}


### PR DESCRIPTION
This pull request enhances error reporting for the node removal process by updating the `RemoveNodeResponse` struct to include detailed error messages from various subsystems. This will make it easier to diagnose issues when node removal is forced and some subsystems fail.

### Error reporting improvements

* Updated the `RemoveNodeResponse` struct in `api/v1/rpc_remove_node.go` to include an `Errors` field, which provides error messages from Kubernetes, Datastore, and Microcluster subsystems.
* Added a new `RemoveNodeErrors` struct to encapsulate error messages from each subsystem, improving clarity and maintainability.