### PR TITLE
docs: Add k8sd API principles and k8s-dqlite removal ADR

### DIFF
--- a/docs/adr/000-template.md
+++ b/docs/adr/000-template.md
@@ -1,0 +1,84 @@
+# ADR [NUMBER]: [Title]
+
+* Status: [Proposed | Accepted | Rejected | Deprecated | Superseded by ADR-XXX]
+* Owner: [Github name]
+
+## Purpose
+
+[A brief statement explaining what this ADR is for and what decision needs to be made. This should be 2-3 sentences that answer:
+
+* What is the problem or question we're addressing?
+* What do we need to agree on?
+* What is the decision? (high-level summary so readers can quickly understand the outcome)]
+
+## Context
+
+[Describe the current situation, background, and forces at play that led to the need for this decision. Include:
+
+* What is the current state?
+* What problem are we trying to solve?
+* What constraints or requirements exist?
+* What relevant technical details should readers understand?]
+
+## Decision
+
+[State the decision clearly and concisely. This should be the what, not the why (that's in Context and Consequences).
+
+Break this into subsections if needed to explain:
+
+* The core decision
+* How it will work
+* Key implementation details]
+
+## Alternatives Considered
+
+### Alternative 1: [Name]
+
+**Description**: [Brief description of the alternative]
+
+**Rejected Because**:
+
+* [Reason 1]
+* [Reason 2]
+* [Reason 3]
+
+### Alternative 2: [Name]
+
+**Description**: [Brief description of the alternative]
+
+**Rejected Because**:
+
+* [Reason 1]
+* [Reason 2]
+
+## Consequences
+
+### Advantages
+
+1. **[Advantage 1]**: [Description]
+2. **[Advantage 2]**: [Description]
+3. **[Advantage 3]**: [Description]
+
+### Trade-offs
+
+1. **[Trade-off 1]**: [Description]
+2. **[Trade-off 2]**: [Description]
+
+### Risks and Mitigations (optional)
+
+**Risk**: [Description of the risk]
+
+**Mitigation**:
+
+* [Mitigation strategy 1]
+* [Mitigation strategy 2]
+
+## Implementation Notes
+
+[Optional section for implementation details, phased rollout plans, migration strategies, or other practical considerations for executing this decision]
+
+## References
+
+* [Link to related documentation]
+* [Link to relevant code or PRs]
+* [Link to related ADRs]

--- a/docs/adr/001-branch-based-versioning.md
+++ b/docs/adr/001-branch-based-versioning.md
@@ -1,0 +1,147 @@
+# ADR 001: Adopt Branch-Based API Versioning
+
+* Status: Accepted
+* Owner: @bschimke95
+
+## Purpose
+
+This ADR establishes the versioning strategy for the k8sd API repository. Specifically, we need to decide how to organize and manage multiple major API versions in the codebase, whether to use separate directories for each version (like Kubernetes) or separate Git branches (like Go modules and microcluster).
+
+**The decision**: We will adopt **branch-based versioning** where the `main` branch contains the latest major version, and older major versions are maintained on separate branches (e.g., `v1`). API files will live directly in `api/*.go`, and the `go.mod` will include the version in the module path for v2+ (e.g., `github.com/canonical/k8s-snap-api/v2`).
+
+## Context
+
+The k8sd API repository previously used a **directory-based versioning** approach where each major version lived in separate directories (`api/v1/`, `api/v2/`) within the same repository. This approach aligns with the Kubernetes API versioning model but does not quite fit the k8sd use case.
+
+### Problems with Directory-Based Versioning
+
+#### Kubernetes-Style API Groups Don't Apply
+
+Kubernetes has the concept of API groups, which allows different parts of their API to evolve independently. This makes sense for their directory-based structure (`apps/v1`, `networking.k8s.io/v1`, etc.).
+
+However, k8sd does not have API groups. This means:
+
+* Either the full API needs to be copied to a new major version directory
+* Or awkward dependencies between `v{N}` and `v{N+1}` arise if types are reused
+
+#### Tagging Challenges
+
+When a type shared between versions needs updating, we face a dilemma:
+
+* Update the `v{N}` struct definition and create a `v{N+1}` tag (but this reflects the change in v2 as well, which is confusing)
+* Copy the entire structure to `v{N+1}` (treating it as a breaking change even if it isn't)
+
+#### Not Idiomatic for Go Modules
+
+The Go module system expects v2+ modules to include the version in the module path:
+
+* Directory-based creates awkward imports: `github.com/canonical/k8s-snap-api/api/v2`
+* The relationship between directories and module versions is unclear
+* Import paths become unnecessarily verbose
+
+#### Complexity for Small Teams
+
+Given k8sd's size and contributor count, there's generally no need for complex feature lifecycle management through alpha → beta → stable as done in upstream Kubernetes. A simpler versioning scheme is more appropriate.
+
+The [microcluster](https://github.com/canonical/microcluster) project successfully uses branch-based versioning, which is the idiomatic Go versioning scheme. So, this approach has proven effective for similar projects and team-sizes within Canonical.
+
+## Decision
+
+We will adopt **branch-based versioning** following Go module best practices and the microcluster model.
+
+### New Versioning Strategy
+
+**Branch-Based Versioning**:
+
+1. **`main` branch** contains the latest major version (currently v2)
+2. **Version branches** (e.g. `v1`) are created to preserve older major versions
+3. **API files** live directly in `api/*.go` (not in versioned subdirectories)
+4. **The `go.mod`** includes major version in module path for v2+: `github.com/canonical/k8s-snap-api/v2`
+5. **Breaking changes** trigger creation of a new version branch and module path update on `main`
+
+### How It Works
+
+**When creating a new major version (e.g., v2 → v3):**
+
+1. Create a `v2` branch from current `main`
+2. Keep developing v3 on `main`
+3. Update `go.mod` on `main` to `github.com/canonical/k8s-snap-api/v3`
+4. Tag the first v3 release as `v3.0.0`
+
+**Backporting to older versions:**
+
+* Bug fixes: Develop on `main` first, then cherry-pick to older version branches
+* Security fixes: Must be backported to all supported versions
+* Features: Generally only on `main`, backport only if critical for older versions
+* Breaking changes: Never backport; create a new major version
+
+**Import paths:**
+
+* v1: `github.com/canonical/k8s-snap-api` (on `v1` branch)
+* v2: `github.com/canonical/k8s-snap-api/v2` (on `main` branch)
+* v3: `github.com/canonical/k8s-snap-api/v3` (on `main` branch, when created)
+
+## Alternatives Considered
+
+### Alternative 1: Keep Directory-Based Versioning (api/v1/, api/v2/)
+
+**Description**: Continue with the previous approach of separate directories for each version.
+
+**Rejected Because**:
+
+* Not idiomatic for Go modules (v2+ should have version in module path)
+* Creates awkward import paths: `github.com/canonical/k8s-snap-api/api/v2`
+* Harder to share code between versions (leads to duplication or awkward dependencies)
+* The relationship between directories and module versions is unclear
+* Tagging becomes confusing when shared types are updated
+
+### Alternative 2: Monorepo with Separate Modules
+
+**Description**: Use separate `go.mod` files for each version in subdirectories, creating multiple independent modules within one repository.
+
+**Rejected Because**:
+
+* More complex to manage multiple modules in one repository
+* Tag management becomes more complex (need to prefix tags with subdirectory paths)
+* Not necessary for k8sd's use case where versions are sequential, not parallel development
+* Adds unnecessary complexity for a small team
+
+### Alternative 3: Separate Repository Per Version
+
+**Description**: Create entirely separate repositories for each major version (k8s-snap-api, k8s-snap-api-v2, etc.).
+
+**Rejected Because**:
+
+* Creates organizational overhead in managing multiple repositories
+* Makes cross-version code review and comparison difficult
+* Fragments the project's history and documentation
+* Overkill for the scale and team size of k8sd
+
+## Consequences
+
+### Advantages
+
+1. **Idiomatic Go**: Follows Go module versioning best practices with version in module path for v2+
+2. **Simpler structure**: No nested version directories, just `api/*.go` files on each branch
+3. **Clear evolution**: `main` is always the latest version, older versions preserved on branches
+
+### Trade-offs
+
+1. **Branch management required**: Need to create and maintain version branches when introducing breaking changes
+
+### Migration from Directory-Based to Branch-Based
+
+The migration involves:
+
+1. Create `v1` branch preserving the old `api/v1/*` structure
+2. Move `api/v2/*` files to `api/*` on `main`
+3. Update `go.mod` on `main` to `github.com/canonical/k8s-snap-api/v2`
+4. Tag `v2.0.0` on `main`
+5. Update client libraries to import `/v2` path
+
+## References
+
+* [k8sd API Versioning Principles](../api-versioning.md)
+* [Microcluster API Versioning](https://github.com/canonical/microcluster)
+* [Go Modules Reference - Version Numbers](https://go.dev/ref/mod#versions)
+* [Semantic Versioning 2.0.0](https://semver.org/)

--- a/docs/adr/002-v2-api-k8s-dqlite-removal.md
+++ b/docs/adr/002-v2-api-k8s-dqlite-removal.md
@@ -1,0 +1,88 @@
+# ADR 002: Create v2 API Without k8s-dqlite Datastore
+
+* Status: Accepted
+* Owner: @bschimke95
+
+## Purpose
+
+This ADR establishes whether we should create a new major API version to remove k8s-dqlite support from the k8sd API. Specifically, we need to decide how to handle the deprecation and removal of k8s-dqlite fields.
+
+**The decision**: We will create a new v2 API that removes all k8s-dqlite related fields and configuration options.
+
+## Context
+
+Canonical Kubernetes has historically supported two datastore options for storing cluster state:
+
+1. **k8s-dqlite**: A custom distributed database based on dqlite (a distributed SQLite implementation)
+2. **etcd**: The standard Kubernetes datastore used by most Kubernetes distributions
+
+### Deprecation Decision
+
+After careful consideration, the decision was made to deprecate k8s-dqlite in Canonical Kubernetes 1.35 with full removal planned for version 1.36.
+
+### API Impact
+
+The current v1 API includes several fields related to k8s-dqlite configuration:
+
+* `BootstrapConfig.K8sDqlitePort`: Port configuration for k8s-dqlite
+* `BootstrapConfig.DatastoreType`: Accepts "k8s-dqlite", "etcd", or "external"
+* `BootstrapConfig.ExtraNodeK8sDqliteArgs`: Additional arguments for k8s-dqlite
+* `ControlPlaneJoinConfig.ExtraNodeK8sDqliteArgs`: Additional arguments for k8s-dqlite
+
+Removing these fields from the existing v1 API would be a breaking change that violates API compatibility guarantees as outlined in the [k8sd API versioning principles](../api-versioning.md).
+
+## Decision
+
+We will **create a new v2 API** that removes all k8s-dqlite related fields and configuration options, while maintaining the v1 API for a transition period in a separate branch.
+
+### v1 API Changes
+
+* Mark `K8sDqlitePort` from `BootstrapConfig` as deprecated.
+* Mark `ExtraNodeK8sDqliteArgs` from `BootstrapConfig` and `ControlPlaneJoinConfig` as deprecated.
+* Add deprecation notice for the `k8s-dqlite` option to the `DatabaseType` config
+
+### v2 API Changes
+
+1. Add deprecation notice to k8s-dqlite fields
+2. Cut `v1` branch
+3. Remove `K8sDqlitePort` from `BootstrapConfig`
+4. Remove `ExtraNodeK8sDqliteArgs` from `BootstrapConfig` and `ControlPlaneJoinConfig`
+5. Change allowed values from "k8s-dqlite | etcd | external" to "etcd | external" for the `DatabaseType` config
+6. Create `v2.0.0` tag
+
+## Alternatives Considered
+
+### Alternative 1: Keep k8s-dqlite Fields but Mark as Deprecated
+
+**Description**: Keep all k8s-dqlite fields in v1 API with deprecation warnings and ignore them in the implementation.
+
+**Rejected Because**:
+
+* Creates confusion for new users who might not notice deprecation warnings
+* Maintains technical debt in the API surface area
+* Could lead to bugs if users attempt to use deprecated fields expecting them to work
+* Doesn't provide a clear signal about the direction of the product
+* Violates the principle of removing unused code
+
+### Alternative 2: Remove Fields from v1 API (Breaking Change)
+
+**Description**: Remove k8s-dqlite fields from v1 API in a breaking manner without creating a new version.
+
+**Rejected Because**:
+
+* Violates API stability guarantees and semantic versioning principles
+
+## Consequences
+
+### Advantages
+
+1. **Cleaner API**: Removes deprecated functionality, making the API easier to understand for new users
+
+### Trade-offs
+
+1. **Migration effort required**: Clients must update imports and remove k8s-dqlite configuration from their code
+
+## References
+
+* [k8sd API Versioning Principles](../api-versioning.md)
+* [ADR 001: Adopt Branch-Based API Versioning](./001-branch-based-versioning.md)

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,170 @@
+# k8sd API Versioning Principles
+
+## Overview
+
+The k8sd API is the core interface for managing Canonical Kubernetes clusters. This document outlines the versioning strategy and guidelines for managing major, minor, and patch versions of the API.
+
+## Versioning Strategy
+
+The k8sd API uses a **branch-based versioning approach** following Go module best practices:
+
+1. **The `main` branch** contains the latest major version (currently v2)
+2. **Release branches** (e.g. `v1`) for older versions are created when a new major version is introduced
+3. **Git tags** track minor and patch versions in the format `vX.Y.Z`
+4. **The `go.mod` file** includes the major version in the module path for v2+
+
+### Version Format
+
+The complete version follows semantic versioning: `vX.Y.Z`
+
+- `X` = Major version (reflected in branch name and module path)
+- `Y` = Minor version (tracked via Git tags)
+- `Z` = Patch version (tracked via Git tags)
+
+**Example tags:**
+
+- `v1.0.0` - Initial release of v1 API (on `v1` branch)
+- `v1.1.0` - v1 API with backward-compatible additions (on `v1` branch)
+- `v1.1.1` - v1 API with bug fixes (on `v1` branch)
+- `v2.0.0` - Initial release of v2 API (on `main` branch)
+- `v2.1.0` - v2 API with backward-compatible additions (on `main` branch)
+
+### How It Works
+
+1. **Active Development on `main`**: The `main` branch always contains the latest major version (e.g., v2)
+2. **API Files in `api/` Directory**: All API types and definitions live directly in `api/*.go` files
+3. **Module Path with Version**: The `go.mod` declares the module as `github.com/canonical/k8s-snap-api/v2`
+4. **Branch for Each Major Version**: When v3 is needed, the current `main` (v2) becomes the `v2` branch
+5. **Backports for Older Versions**: Bug fixes and features can be backported from `main` to older version branches
+
+Note that this structure was adopted for `v2`. The `v1` branch has a slightly different structure.
+See [ADR 001: Adopt Branch-Based API Versioning] for details.
+
+## When to Create a New Major Version (New Branch)
+
+A new major version **MUST** be created when making **breaking changes** to the API. Breaking changes include:
+
+### 1. Removing Fields or Endpoints
+
+- Removing fields from request or response structures
+- Removing RPC endpoints
+
+### 2. Changing Field Types or Semantics
+
+- Changing the data type of an existing field (e.g., `string` → `int`)
+- Changing the meaning or behavior of a field
+- Changing validation rules that would reject previously valid values
+
+### 3. Renaming Fields or Endpoints
+
+- Renaming API fields (JSON/YAML keys)
+- Renaming RPC endpoints
+- Changing field serialization names
+
+### 4. Changing Default Behaviors
+
+- Modifying default values in ways that change cluster behavior
+
+### 5. Removing or Changing Enum Values
+
+- Removing allowed values from fields with restricted sets
+- Example: Removing `k8s-dqlite` from the allowed `DatastoreType` values
+
+### 6. Making Required Fields Optional or Vice Versa
+
+- Changes that affect whether fields must be provided
+
+**When a breaking change is introduced:**
+
+1. **Create a release branch** for the current major version:
+
+   ```bash
+   # If currently on main with v2
+   git checkout main
+   git checkout -b v2
+   git push origin v2
+   ```
+
+2. **Update `go.mod` on `main`** to the next major version:
+
+   ```go
+   module github.com/canonical/k8s-snap-api/v3
+   ```
+
+   Note that `v1` does not contain a suffix.
+
+3. **Make breaking changes** in `api/*.go` files on `main`
+
+4. **Tag the first release** of the new version:
+
+   ```bash
+   git tag -a v3.0.0 -m "Release v3.0.0: Breaking changes description"
+   git push origin v3.0.0
+   ```
+
+5. **Update import paths** in consuming code:
+
+   ```go
+   // Old
+   import "github.com/canonical/k8s-snap-api/v2/api"
+
+   // New
+   import "github.com/canonical/k8s-snap-api/v3/api"
+   ```
+
+## When to Create a New Minor Version
+
+Minor versions are tracked via Git tags **without creating a new branch**. A minor version bump (e.g., `v2.0.0` → `v2.1.0`) is appropriate for backward-compatible changes that add functionality:
+
+### 1. Adding New Optional Fields
+
+- Adding new fields to structs that have default values
+- New fields must be optional and must not change existing behavior when omitted
+- Files are modified on the appropriate branch (e.g., `main` for v2, or `v1` branch for v1)
+
+### 2. Adding New Endpoints
+
+- Introducing new RPC methods while keeping existing ones unchanged
+- New `rpc_*.go` files are added to the `api/` directory
+
+### 3. Adding New Enum Values
+
+- Adding new allowed values to existing fields with restricted sets
+- Existing values continue to work as before
+
+### 4. Adding New Types
+
+- Introducing new types that don't modify existing types
+- New `type_*.go` files are added to the `api/` directory
+
+**When adding backward-compatible features:**
+
+1. Modify files in `api/` on the appropriate branch
+2. Commit the changes
+3. Tag the release: `v{N}.{Y+1}.0`
+4. Push the tag
+
+## When to Create a New Patch Version
+
+Patch versions are tracked via Git tags **without creating a new branch**. A patch version bump (e.g., `v2.1.0` → `v2.1.1`) is appropriate for backward-compatible bug fixes:
+
+### 1. Documentation Fixes
+
+- Correcting comments, documentation, or examples
+- Clarifying field descriptions
+
+### 3. Code Quality
+
+- Repository changes that don't change the API contract
+
+**When fixing bugs:**
+
+1. Fix the bug in `api/` files on the appropriate branch
+2. Commit the fix
+3. Tag the release: `v{N}.{Y}.{Z+1}`
+4. Push the tag
+
+
+<!-- Links -->
+
+[ADR 001: Adopt Branch-Based API Versioning]: (./adr/001-branch-based-versioning.md)


### PR DESCRIPTION
This PR contains two commits (will not be squashed on merge):
1. Introduce the `k8sd` API principles along with a ADR that explains/proposes this change
2. An ADR that explains why a v2 API needs to be introduced.