### PR TITLE
docs: ControlPlaneJoinConfig k8s-dqlite deprecation

### DIFF
--- a/api/v1/type_control_plane_join_config.go
+++ b/api/v1/type_control_plane_join_config.go
@@ -106,6 +106,9 @@ type ControlPlaneJoinConfig struct {
 	// A parameter that is explicitly set to `null` is deleted.
 	// The format is `map[<--flag-name>]<value>`.
 	ExtraNodeContainerdArgs map[string]*string `json:"extra-node-containerd-args,omitempty" yaml:"extra-node-containerd-args,omitempty"`
+	// Deprecated: k8s-dqlite is being deprecated and will be removed in Canonical Kubernetes 1.36 without an upgrade path.
+	// We recommend against bootstrapping new clusters with k8s-dqlite.
+	//
 	// Additional arguments that are passed to `k8s-dqlite` only for that specific node.
 	// A parameter that is explicitly set to `null` is deleted.
 	// The format is `map[<--flag-name>]<value>`.


### PR DESCRIPTION
Follow-up to #47 