### PR TITLE
feat: add kube-proxy-enable field

### DIFF
--- a/api/rpc_get_worker_join_info.go
+++ b/api/rpc_get_worker_join_info.go
@@ -44,4 +44,6 @@ type GetWorkerJoinInfoResponse struct {
 	// Annotations is a map of strings that can be used to store arbitrary metadata configuration.
 	// Please refer to the ClusterAPI annotations reference for further details on these options.
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// KubeProxyFree indicates if kube-proxy should be disabled
+	KubeProxyFree bool `json:"kube-proxy-free,omitempty"`
 }

--- a/api/rpc_get_worker_join_info.go
+++ b/api/rpc_get_worker_join_info.go
@@ -44,6 +44,6 @@ type GetWorkerJoinInfoResponse struct {
 	// Annotations is a map of strings that can be used to store arbitrary metadata configuration.
 	// Please refer to the ClusterAPI annotations reference for further details on these options.
 	Annotations map[string]string `json:"annotations,omitempty"`
-	// KubeProxyFree indicates if kube-proxy should be disabled
-	KubeProxyFree bool `json:"kube-proxy-free,omitempty"`
+	// KubeProxyEnabled indicates if kube-proxy should be enabled
+	KubeProxyEnabled bool `json:"kube-proxy-enabled,omitempty"`
 }

--- a/api/type_cluster_config.go
+++ b/api/type_cluster_config.go
@@ -145,11 +145,16 @@ type NetworkConfig struct {
 	// Determines if kube-proxy should be enabled.
 	// When network is enabled, this is implicitly false.
 	// If omitted defaults to `true`.
-	KubeProxyEnabled *bool `json:"kube-proxy-enabled,omitempty" yaml:"kube-proxy-enabled,omitempty"`
+	KubeProxyEnabled *bool `json:"kube-proxy-enabled" yaml:"kube-proxy-enabled"`
 }
 
-func (c NetworkConfig) GetEnabled() bool          { return util.Deref(c.Enabled) }
-func (c NetworkConfig) GetKubeProxyEnabled() bool { return util.Deref(c.KubeProxyEnabled) }
+func (c NetworkConfig) GetEnabled() bool { return util.Deref(c.Enabled) }
+func (c NetworkConfig) GetKubeProxyEnabled() bool {
+	if c.KubeProxyEnabled == nil {
+		return true
+	}
+	return util.Deref(c.KubeProxyEnabled)
+}
 
 type GatewayConfig struct {
 	// Determines if the feature should be enabled.

--- a/api/type_cluster_config.go
+++ b/api/type_cluster_config.go
@@ -142,9 +142,14 @@ type NetworkConfig struct {
 	// Determines if the feature should be enabled.
 	// If omitted defaults to `true`
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	// Determines if kube-proxy should be disabled.
+	// When network is enabled, this is implicitly true.
+	// If omitted defaults to `false`
+	KubeProxyFree *bool `json:"kube-proxy-free,omitempty" yaml:"kube-proxy-free,omitempty"`
 }
 
-func (c NetworkConfig) GetEnabled() bool { return util.Deref(c.Enabled) }
+func (c NetworkConfig) GetEnabled() bool       { return util.Deref(c.Enabled) }
+func (c NetworkConfig) GetKubeProxyFree() bool { return util.Deref(c.KubeProxyFree) }
 
 type GatewayConfig struct {
 	// Determines if the feature should be enabled.

--- a/api/type_cluster_config.go
+++ b/api/type_cluster_config.go
@@ -142,14 +142,14 @@ type NetworkConfig struct {
 	// Determines if the feature should be enabled.
 	// If omitted defaults to `true`
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	// Determines if kube-proxy should be disabled.
-	// When network is enabled, this is implicitly true.
-	// If omitted defaults to `false`
-	KubeProxyFree *bool `json:"kube-proxy-free,omitempty" yaml:"kube-proxy-free,omitempty"`
+	// Determines if kube-proxy should be enabled.
+	// When network is enabled, this is implicitly false.
+	// If omitted defaults to `true`.
+	KubeProxyEnabled *bool `json:"kube-proxy-enabled,omitempty" yaml:"kube-proxy-enabled,omitempty"`
 }
 
-func (c NetworkConfig) GetEnabled() bool       { return util.Deref(c.Enabled) }
-func (c NetworkConfig) GetKubeProxyFree() bool { return util.Deref(c.KubeProxyFree) }
+func (c NetworkConfig) GetEnabled() bool          { return util.Deref(c.Enabled) }
+func (c NetworkConfig) GetKubeProxyEnabled() bool { return util.Deref(c.KubeProxyEnabled) }
 
 type GatewayConfig struct {
 	// Determines if the feature should be enabled.


### PR DESCRIPTION
Introduce a boolean kube-proxy-enable field. That is always returned even if empty and any helper functions treat nil as True.