### PR TITLE
feat: add MetalLB multi-peer BGP annotation constants

### DIFF
--- a/api/annotations/metallb/metallb.go
+++ b/api/annotations/metallb/metallb.go
@@ -1,0 +1,24 @@
+// Package metallb defines annotation keys for the MetalLB load-balancer feature.
+// Keys under v1alpha1 are experimental and may change without notice.
+package metallb
+
+const (
+	// AnnotationBGPPeers holds a YAML-encoded list of BGP peer configs for multi-peer
+	// MetalLB BGP mode. Each item may include: peerAddress (required), peerASN (required),
+	// myASN (optional, falls back to load-balancer.bgp-local-asn), peerPort (optional,
+	// default 179), nodeSelector (optional, map[string]string of matchLabels).
+	//
+	// Example value:
+	//   - peerAddress: 10.116.3.164
+	//     peerASN: 65001
+	//     nodeSelector: {topology.kubernetes.io/zone: i1}
+	//
+	// When set, this annotation REPLACES the single-peer typed BGP keys entirely.
+	// Invalid YAML causes the load-balancer feature to enter a degraded state.
+	AnnotationBGPPeers = "k8sd/v1alpha1/metallb/bgp-peers"
+
+	// AnnotationAdvertiseAllPools controls the BGPAdvertisement spec. When "true",
+	// the BGPAdvertisement is emitted with an empty spec (advertises all IP pools).
+	// When unset or "false", only the named IPAddressPool is advertised.
+	AnnotationAdvertiseAllPools = "k8sd/v1alpha1/metallb/advertise-all-pools"
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,3 @@
-// Version: v2.2.0
 module github.com/canonical/k8s-snap-api/v2
 
 go 1.25.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Version: v2.2.0
 module github.com/canonical/k8s-snap-api/v2
 
 go 1.25.0


### PR DESCRIPTION
## Summary

Adds a new `api/annotations/metallb` package with constants for the alpha multi-peer BGP annotation interface:

- `AnnotationBGPPeers = "k8sd/v1alpha1/metallb/bgp-peers"` — YAML-encoded list of BGPPeer configurations
- `AnnotationAdvertiseAllPools = "k8sd/v1alpha1/metallb/advertise-all-pools"` — bool string

The `v1alpha1` prefix signals that this interface is alpha and may change without a deprecation period.

## Usage

```bash
sudo k8s set 'annotations.k8sd/v1alpha1/metallb/bgp-peers=
- peerAddress: 10.116.3.164
  peerASN: 65001
  myASN: 65000
  nodeSelector:
    topology.kubernetes.io/zone: i1
- peerAddress: 10.116.3.165
  peerASN: 65002
  nodeSelector:
    topology.kubernetes.io/zone: i2
'
```

## Notes

- This is the foundation for multi-peer BGP support in k8sd (companion PR there depends on this).
- Once this PR is merged, a git tag `v2/v2.2.0` should be created so k8sd can reference it without a replace directive.

## Test plan

No logic — constants only. Verified with `go vet ./...`.